### PR TITLE
feat: add dns-controller chart

### DIFF
--- a/incubator/dns-controller/Chart.yaml
+++ b/incubator/dns-controller/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: dns-controller
+description: Kubernetes DNS Controller - 自动同步 Service 到腾讯云 PrivateDNS
+type: application
+version: 1.1.1
+appVersion: v1.1.1
+icon: https://cloudcache.tencent-cloud.com/qcloud/ui/static/other_external_resource/56f6fa28-dc5b-4541-b8f9-f0813f714d43.svg
+keywords:
+  - dns
+  - kubernetes
+  - tencent-cloud
+  - privatedns
+  - webhook
+home: https://git.woa.com/kateway/dns-controller
+sources:
+  - https://git.woa.com/kateway/dns-controller
+maintainers:
+  - name: DNS Controller Team
+    email: wallaceqian@tencent.com
+kubeVersion: ">=1.24.0-0"
+annotations:
+  catalog.cattle.io/display-name: DNS Controller
+  catalog.cattle.io/namespace: kube-system

--- a/incubator/dns-controller/README.md
+++ b/incubator/dns-controller/README.md
@@ -1,0 +1,212 @@
+# DNS Controller Helm Chart
+
+自动同步 Kubernetes Service 到腾讯云 PrivateDNS 的 Helm Chart。
+
+## 功能特性
+
+- ✅ 自动同步 ClusterIP/NodePort/LoadBalancer Service 到 PrivateDNS
+- ✅ 支持 Headless Service (StatefulSet Pod DNS)
+- ✅ 支持 ExternalName Service
+- ✅ Pod DNS 自动注入（通过 Webhook）
+- ✅ DNS 记录垃圾回收
+- ✅ 高可用部署（Leader Election）
+- ✅ Prometheus 指标监控
+
+## 安装前准备
+
+### 必需参数
+
+- `config.clusterId`: 集群 ID
+- `config.vpcId`: VPC ID
+- `config.region`: 腾讯云地域
+- `credentials.secretId`: 腾讯云 Secret ID
+- `credentials.secretKey`: 腾讯云 Secret Key
+
+### 可选参数
+
+- `config.dnsSuffix`: DNS 后缀 (默认: local)
+- `webhook.enabled`: 是否启用 Webhook (默认: true)
+- `privateDNS.enableGlobal`: 是否覆盖 kube-dns (默认: false)
+
+## 安装方式
+
+### 使用 values 文件 (推荐)
+
+创建 `my-values.yaml`:
+
+```yaml
+config:
+  clusterId: "cls-xxxxxxxx"
+  vpcId: "vpc-xxxxxxxx"
+  region: "ap-guangzhou"
+
+credentials:
+  secretId: "AKIDxxxxxx"
+  secretKey: "xxxxxx"
+
+# 可选: 启用全局 DNS
+privateDNS:
+  enableGlobal: false
+
+# 可选: 禁用 Webhook
+webhook:
+  enabled: true
+```
+
+安装:
+
+```bash
+helm install dns-controller . -n kube-system \
+  -f my-values.yaml
+```
+
+### 使用命令行参数
+
+```bash
+helm install dns-controller . -n kube-system \
+  --set config.clusterId=cls-xxxxxxxx \
+  --set config.vpcId=vpc-xxxxxxxx \
+  --set config.region=ap-guangzhou \
+  --set credentials.secretId=AKIDxxxxxx \
+  --set credentials.secretKey=xxxxxx
+```
+
+## 验证安装
+
+查看 Pod 状态:
+
+```bash
+kubectl get pods -n kube-system -l app.kubernetes.io/name=dns-controller
+```
+
+查看日志:
+
+```bash
+kubectl logs -n kube-system -l app.kubernetes.io/name=dns-controller -f
+```
+
+## 升级
+
+```bash
+helm upgrade dns-controller . -n kube-system \
+  -f my-values.yaml
+```
+
+## 卸载
+
+```bash
+helm uninstall dns-controller
+```
+
+## 配置参数
+
+### 基本配置
+
+| 参数 | 描述 | 默认值 | 必需 |
+|------|------|--------|------|
+| `image.repository` | 镜像仓库 | `ccr.ccs.tencentyun.com/tke-market/dns-controller` | 否 |
+| `image.tag` | 镜像标签 | `v1.1.1` | 否 |
+| `image.pullPolicy` | 镜像拉取策略 | `IfNotPresent` | 否 |
+| `replicas` | 副本数 | `2` | 否 |
+| `config.clusterId` | 集群 ID | `""` | 是 |
+| `config.vpcId` | VPC ID | `""` | 是 |
+| `config.region` | 腾讯云地域 | `ap-guangzhou` | 是 |
+| `config.dnsSuffix` | DNS 后缀 | `local` | 否 |
+
+### 凭证配置
+
+| 参数 | 描述 | 默认值 | 必需 |
+|------|------|--------|------|
+| `credentials.secretId` | 腾讯云 Secret ID | `""` | 是 |
+| `credentials.secretKey` | 腾讯云 Secret Key | `""` | 是 |
+
+### 日志和监控
+
+| 参数 | 描述 | 默认值 |
+|------|------|--------|
+| `log.level` | 日志级别 (debug/info/warn/error) | `info` |
+| `metrics.enabled` | 是否启用指标 | `true` |
+| `metrics.addr` | 指标服务地址 | `:8080` |
+| `health.addr` | 健康检查地址 | `:8081` |
+
+### PrivateDNS 配置
+
+| 参数 | 描述 | 默认值 |
+|------|------|--------|
+| `privateDNS.qps` | QPS 限制 | `90.0` |
+| `privateDNS.timeout` | API 超时时间 | `10s` |
+| `privateDNS.debug` | 是否启用 debug 日志 | `false` |
+| `privateDNS.enableGlobal` | 是否覆盖 kube-dns | `false` |
+| `privateDNS.nameservers` | Nameserver 地址列表 | `[183.60.83.19, 183.60.82.98]` |
+
+### 控制器配置
+
+| 参数 | 描述 | 默认值 |
+|------|------|--------|
+| `controller.leaderElection` | 是否启用 Leader 选举 | `true` |
+| `controller.concurrentWorkers` | 并发 worker 数 | `10` |
+| `controller.reconcileInterval` | 全量对账间隔 | `10m` |
+| `controller.requeueAfter` | 失败重试间隔 | `30s` |
+| `controller.maxConcurrentApi` | 最大并发 API 数 | `10` |
+
+### Webhook 配置
+
+| 参数 | 描述 | 默认值 |
+|------|------|--------|
+| `webhook.enabled` | 是否启用 Webhook | `true` |
+| `webhook.port` | Webhook 服务端口 | `9443` |
+
+### 垃圾回收配置
+
+| 参数 | 描述 | 默认值 |
+|------|------|--------|
+| `gc.enabled` | 是否启用 GC | `true` |
+| `gc.interval` | GC 运行间隔 | `30m` |
+| `gc.safetyPeriod` | 安全期 | `5m` |
+| `gc.concurrency` | GC 并发数 | `3` |
+| `gc.maxDeletePerRun` | 每次最多删除数 | `100` |
+| `gc.dryRun` | 是否为 Dry Run 模式 | `false` |
+
+### 资源配置
+
+| 参数 | 描述 | 默认值 |
+|------|------|--------|
+| `resources.limits.cpu` | CPU 限制 | `200m` |
+| `resources.limits.memory` | 内存限制 | `256Mi` |
+| `resources.requests.cpu` | CPU 请求 | `50m` |
+| `resources.requests.memory` | 内存请求 | `128Mi` |
+
+## 故障排查
+
+### Pod 启动失败
+
+```bash
+# 查看 Pod 事件
+kubectl describe pod -n kube-system -l app.kubernetes.io/name=dns-controller
+
+# 查看日志
+kubectl logs -n kube-system -l app.kubernetes.io/name=dns-controller
+```
+
+### 权限问题
+
+确认 ServiceAccount 和 ClusterRole 已创建:
+
+```bash
+kubectl get sa dns-controller -n kube-system
+kubectl get clusterrole dns-controller
+kubectl get clusterrolebinding dns-controller
+```
+
+### DNS 同步失败
+
+检查配置和凭证:
+
+```bash
+kubectl get configmap dns-controller-config -n kube-system -o yaml
+kubectl get secret privatedns-credentials -n kube-system
+```
+
+## 更多信息
+
+- 项目地址: https://git.woa.com/kateway/dns-controller

--- a/incubator/dns-controller/templates/_helpers.tpl
+++ b/incubator/dns-controller/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+扩展 Chart 名称
+*/}}
+{{- define "dns-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+创建完整的 Chart 名称
+*/}}
+{{- define "dns-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart 名称和版本
+*/}}
+{{- define "dns-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+通用标签
+*/}}
+{{- define "dns-controller.labels" -}}
+helm.sh/chart: {{ include "dns-controller.chart" . }}
+{{ include "dns-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+选择器标签
+*/}}
+{{- define "dns-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dns-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: controller
+{{- end }}
+
+{{/*
+创建 ServiceAccount 名称
+*/}}
+{{- define "dns-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dns-controller.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+创建 Secret 名称
+*/}}
+{{- define "dns-controller.secretName" -}}
+{{- if .Values.credentials.existingSecret }}
+{{- .Values.credentials.existingSecret }}
+{{- else }}
+{{- include "dns-controller.fullname" . }}-credentials
+{{- end }}
+{{- end }}

--- a/incubator/dns-controller/templates/configmap.yaml
+++ b/incubator/dns-controller/templates/configmap.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dns-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dns-controller.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    # DNS Controller 配置文件
+    
+    # 基本配置
+    clusterId: {{ required "config.clusterId is required" .Values.config.clusterId | quote }}
+    vpcId: {{ required "config.vpcId is required" .Values.config.vpcId | quote }}
+    region: {{ required "config.region is required" .Values.config.region | quote }}
+    secretId: {{ required "credentials.secretId is required" .Values.credentials.secretId | quote }}
+    secretKey: {{ required "credentials.secretKey is required" .Values.credentials.secretKey | quote }}
+    dnsSuffix: {{ .Values.config.dnsSuffix | quote }}
+    
+    # 日志配置
+    log:
+      level: {{ .Values.log.level | quote }}
+    
+    # 指标配置
+    metrics:
+      enabled: {{ .Values.metrics.enabled }}
+      addr: {{ .Values.metrics.addr | quote }}
+    
+    # 健康检查配置
+    health:
+      addr: {{ .Values.health.addr | quote }}
+    
+    # PrivateDNS 配置
+    privateDNS:
+      qps: {{ .Values.privateDNS.qps }}
+      timeout: {{ .Values.privateDNS.timeout | quote }}
+      debug: {{ .Values.privateDNS.debug }}
+      enableGlobal: {{ .Values.privateDNS.enableGlobal }}
+      nameservers:
+        {{- range .Values.privateDNS.nameservers }}
+        - {{ . | quote }}
+        {{- end }}
+    
+    # 控制器配置
+    controller:
+      leaderElection: {{ .Values.controller.leaderElection }}
+      concurrentWorkers: {{ .Values.controller.concurrentWorkers }}
+      reconcileInterval: {{ .Values.controller.reconcileInterval | quote }}
+      requeueAfter: {{ .Values.controller.requeueAfter | quote }}
+      maxConcurrentApi: {{ .Values.controller.maxConcurrentApi }}
+      retry:
+        maxAttempts: {{ .Values.controller.retry.maxAttempts }}
+        initialWait: {{ .Values.controller.retry.initialWait | quote }}
+        maxWait: {{ .Values.controller.retry.maxWait | quote }}
+    
+    # Webhook 配置
+    webhook:
+      enable: {{ .Values.webhook.enabled }}
+      port: {{ .Values.webhook.port }}
+      certDir: "/app/data/certs"
+    
+    # 垃圾回收配置
+    garbageCollect:
+      enabled: {{ .Values.gc.enabled }}
+      interval: {{ .Values.gc.interval | quote }}
+      safetyPeriod: {{ .Values.gc.safetyPeriod | quote }}
+      concurrency: {{ .Values.gc.concurrency }}
+      maxDeletePerRun: {{ .Values.gc.maxDeletePerRun }}
+      dryRun: {{ .Values.gc.dryRun }}
+      runOnLeaderElection: {{ .Values.gc.runOnLeaderElection }}

--- a/incubator/dns-controller/templates/deployment.yaml
+++ b/incubator/dns-controller/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dns-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dns-controller.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "dns-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "dns-controller.selectorLabels" . | nindent 8 }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.forceRestart }}
+        kubectl.kubernetes.io/restartedAt: {{ now | date "2006-01-02T15:04:05Z07:00" | quote }}
+        {{- end }}
+    spec:
+      serviceAccountName: dns-controller
+      dnsPolicy: Default
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: dns-controller
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /app/bin/dns-controller
+          args:
+            - --config=/app/conf/config.yaml
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: health
+              containerPort: 8081
+              protocol: TCP
+            {{- if .Values.webhook.enabled }}
+            - name: webhook
+              containerPort: {{ .Values.webhook.port }}
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/conf
+              readOnly: true
+            {{- if .Values.webhook.enabled }}
+            - name: certs
+              mountPath: /app/data/certs
+            {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: false
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "dns-controller.fullname" . }}
+        {{- if .Values.webhook.enabled }}
+        - name: certs
+          emptyDir: {}
+        {{- end }}

--- a/incubator/dns-controller/templates/role.yaml
+++ b/incubator/dns-controller/templates/role.yaml
@@ -1,0 +1,55 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dns-controller.fullname" . }}
+  labels:
+    {{- include "dns-controller.labels" . | nindent 4 }}
+rules:
+  # Service 资源权限
+  # - Service Controller: get, list, watch (监听 Service 变化)
+  # - Endpoints Controller: get, list, watch (读取关联的 Service)
+  # - GC: get (检查 Service 是否存在)
+  # - enableGlobal: update (更新 kube-dns service 移除 selector)
+  # - Webhook: patch (Server-Side Apply 创建 webhook service)
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  
+  # Service 状态权限
+  # - Service Controller: get (读取 Service 状态)
+  - apiGroups: [""]
+    resources: ["services/status"]
+    verbs: ["get"]
+  
+  # Endpoints 资源权限
+  # - Endpoints Controller: get, list, watch (监听 Endpoints 变化)
+  # - enableGlobal: create, update, patch (CreateOrUpdate kube-dns endpoints)
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  
+  # Namespace 资源权限
+  # - Webhook: get, list, watch (检查 namespace label 用于灰度控制)
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  
+  # Event 记录权限
+  # - Service Controller: create, patch (记录事件)
+  # - Endpoints Controller: create, patch (记录事件)
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  
+  # Lease 权限
+  # - Leader Election: 所有操作
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  
+  # MutatingWebhookConfiguration 权限
+  # - Webhook: get, list, watch (controller-runtime cache 需要这些权限进行初始化和状态同步)
+  # - Webhook: create, update, patch (Server-Side Apply 创建/更新 webhook 配置)
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/incubator/dns-controller/templates/rolebinding.yaml
+++ b/incubator/dns-controller/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dns-controller.fullname" . }}
+  labels:
+    {{- include "dns-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dns-controller.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dns-controller.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/incubator/dns-controller/templates/serviceaccount.yaml
+++ b/incubator/dns-controller/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dns-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dns-controller.labels" . | nindent 4 }}

--- a/incubator/dns-controller/templates/webhook-service.yaml
+++ b/incubator/dns-controller/templates/webhook-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dns-controller.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dns-controller.labels" . | nindent 4 }}
+    component: webhook
+spec:
+  type: ClusterIP
+  ports:
+    - name: webhook
+      port: 443
+      targetPort: webhook
+      protocol: TCP
+  selector:
+    {{- include "dns-controller.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/incubator/dns-controller/values-example.yaml
+++ b/incubator/dns-controller/values-example.yaml
@@ -1,0 +1,38 @@
+# DNS Controller Helm Chart 配置示例
+# 使用方式: helm install dns-controller ./deploy/helm/dns-controller -f values-example.yaml
+
+# 基本配置（必需）
+config:
+  clusterId: "cls-xxxxxxxx"       # 替换为你的集群 ID
+  vpcId: "vpc-xxxxxxxx"           # 替换为你的 VPC ID
+  region: "ap-guangzhou"          # 腾讯云地域
+
+# 腾讯云凭证配置（必需）
+credentials:
+  secretId: "AKIDxxxxxxxxxxxxxxxx"
+  secretKey: "xxxxxxxxxxxxxxxx"
+
+# 以下为可选配置，使用默认值即可
+# 如需自定义，取消注释并修改
+
+# # PrivateDNS 配置
+# privateDNS:
+#   enableGlobal: false # 是否覆盖 kube-dns（谨慎开启）
+
+# # Webhook 配置
+# webhook:
+#   enabled: true  # 是否启用 Pod DNS 注入
+
+# # 垃圾回收配置
+# gc:
+#   enabled: true
+#   interval: "30m"
+
+# # 资源配置
+# resources:
+#   limits:
+#     cpu: 200m
+#     memory: 256Mi
+#   requests:
+#     cpu: 50m
+#     memory: 128Mi

--- a/incubator/dns-controller/values.yaml
+++ b/incubator/dns-controller/values.yaml
@@ -1,0 +1,107 @@
+# DNS Controller Helm Chart 配置
+
+# 基本配置
+config:
+  # 集群 ID (必需)
+  clusterId: ""
+  
+  # VPC ID (必需)
+  vpcId: ""
+  
+  # 腾讯云地域 (必需)
+  region: "ap-guangzhou"
+  
+  # DNS 后缀，完整域名格式: {clusterId}.{dnsSuffix}
+  dnsSuffix: "local"
+
+# 腾讯云凭证配置 (必需)
+credentials:
+  # 腾讯云 Secret ID
+  secretId: ""
+  # 腾讯云 Secret Key
+  secretKey: ""
+
+# 镜像配置
+image:
+  repository: ccr.ccs.tencentyun.com/tke-market/dns-controller
+  tag: "v1.1.1"
+  pullPolicy: Always
+
+# 副本数
+replicas: 2
+
+# 强制重启 Pod（每次 helm upgrade 都会重建 Pod，即使没有配置变更）
+forceRestart: true
+
+# Pod 反亲和性配置
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - dns-controller
+          topologyKey: kubernetes.io/hostname
+
+# 日志配置
+log:
+  level: "info"  # 日志级别: debug, info, warn, error
+
+# 指标配置
+metrics:
+  enabled: true
+  addr: ":8080"
+
+# 健康检查配置
+health:
+  addr: ":8081"
+
+# PrivateDNS 配置
+privateDNS:
+  qps: 90.0  # QPS 限制（腾讯云 PrivateDNS 限制 100，建议留 10 安全边界）
+  timeout: "10s"  # API 调用超时时间
+  debug: false  # 是否启用 debug 模式（会打印详细的 API 请求日志）
+  enableGlobal: false  # 是否启用全局 DNS 解析（覆盖 kube-dns）
+  nameservers:  # PrivateDNS Nameserver 地址
+    - "183.60.83.19"
+    - "183.60.82.98"
+
+# 控制器配置
+controller:
+  leaderElection: true  # 是否启用 Leader 选举（多副本部署时必须启用）
+  concurrentWorkers: 10  # 并发 worker 数量（建议不超过 50）
+  reconcileInterval: "10m"  # 全量对账间隔
+  requeueAfter: "30s"  # 失败重试间隔
+  maxConcurrentApi: 10  # 最大并发 API 调用数
+  retry:
+    maxAttempts: 3  # 最大重试次数
+    initialWait: "1s"  # 初始等待时间
+    maxWait: "60s"  # 最大等待时间
+
+# Webhook 配置
+webhook:
+  enabled: true  # 是否启用 Webhook（默认开启）
+  port: 9443  # Webhook 服务端口
+
+# 垃圾回收配置
+gc:
+  enabled: true  # 是否启用 GC
+  interval: "30m"  # GC 运行间隔
+  safetyPeriod: "5m"  # 安全期（资源删除后多久才能被 GC）
+  concurrency: 3  # GC 并发数
+  maxDeletePerRun: 100  # 每次 GC 最多删除的资源数
+  dryRun: false  # 是否为 Dry Run 模式（仅打印，不实际删除）
+  runOnLeaderElection: true  # 是否在 Leader 选举时立即运行一次 GC
+
+# 资源限制
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 50m
+    memory: 128Mi


### PR DESCRIPTION
## Summary

Add dns-controller helm chart to incubator.

DNS Controller automatically syncs Kubernetes Services to Tencent Cloud PrivateDNS.

## Features

- Automatic DNS record sync for ClusterIP Services
- Rate limiting and retry with exponential backoff
- Prometheus metrics and structured logging
- Leader election for HA deployment
- Admission webhook for Service validation
- Garbage collection for orphaned DNS records

## Chart Info

- Chart version: 1.1.0
- App version: v1.1.0
- Image: ccr.ccs.tencentyun.com/tke-market/dns-controller:v1.1.0
- Kubernetes version: >=1.24.0