### PR TITLE
chore: 更新 web 镜像 tag 为 1.5.0-tke，修复CVE-2025-66478漏洞

### DIFF
--- a/incubator/tke-dify/values.yaml
+++ b/incubator/tke-dify/values.yaml
@@ -6,7 +6,7 @@ image:
 
   web:
     repository: ccr.ccs.tencentyun.com/tke-market/dify-web
-    tag: "1.5.0"
+    tag: "1.5.0-tke"
     pullPolicy: IfNotPresent
 
   sandbox:


### PR DESCRIPTION
<img width="1434" height="567" alt="Clipboard_Screenshot_1767067828" src="https://github.com/user-attachments/assets/00f4d3cf-b5e8-4796-b876-535357ca672d" />
