### PR TITLE
feat: opentelemetry operator 0.91.2

### DIFF
--- a/incubator/opentelemetry-operator/Chart.yaml
+++ b/incubator/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tencent-opentelemetry-operator
-version: 0.91.1
+version: 0.91.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -9,5 +9,5 @@ sources:
 maintainers:
   - name: erichchen
 icon: https://cloudcache.tencent-cloud.com/qcloud/ui/static/Industry_tke/80444e53-c142-4896-bc8a-ef4ecf75c682.png
-appVersion: 0.91.1
+appVersion: v0.91.2
 kubeVersion: '>= 1.19.0-0'

--- a/incubator/opentelemetry-operator/templates/_helpers.tpl
+++ b/incubator/opentelemetry-operator/templates/_helpers.tpl
@@ -150,3 +150,41 @@ Modify kubeRBACProxy image repository by region.
 {{- $parts := regexSplit "/" .Values.kubeRBACProxy.image.repository -1 -}}
 {{- printf "%s/%s" (include "regionRepositoryMap" .Values.env.TKE_REGION) (join "/" (slice $parts 1 (len $parts))) -}}
 {{- end -}}
+
+{{/*
+Instrumentation resource spec definition.
+用于在多个地方复用 Instrumentation 资源定义
+*/}}
+{{- define "opentelemetry-operator.instrumentation" -}}
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: default-instrumentation
+  namespace: opentelemetry-operator-system
+spec:
+  exporter:
+    endpoint: {{ .Values.env.ENDPOINT | quote | trim }}
+  propagators:
+    - tracecontext
+    - baggage
+    - b3
+  resource:
+    resourceAttributes:
+      token: {{ .Values.env.APM_TOKEN }}
+  java:
+    image:
+  nodejs:
+    image:
+  python:
+    image:
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: {{ printf "%s/otlp" (include "opentelemetry-operator.host" . ) | quote | trim }}
+  dotnet:
+    image:
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: {{ printf "%s/otlp" (include "opentelemetry-operator.host" . ) | quote | trim }}
+  go:
+    image: ccr.ccs.tencentyun.com/tapm/autoinstrumentation-go:v0.8.0-alpha
+{{- end -}}

--- a/incubator/opentelemetry-operator/templates/_helpers.tpl
+++ b/incubator/opentelemetry-operator/templates/_helpers.tpl
@@ -82,10 +82,16 @@ Create an ordered name of the MutatingWebhookConfiguration
 
 
 {{- define "opentelemetry-operator.host" -}}
-{{- $endpoint :=.Values.env.ENDPOINT}}
+{{- $endpoint := .Values.env.ENDPOINT }}
 {{- $ss := $endpoint | split ":" -}}
-{{- printf "%s:%s" (index $ss "_0") (index $ss "_1") -}}
-{{end}}
+{{- $scheme := index $ss "_0" -}}
+{{- $host := index $ss "_1" | trimPrefix "//" -}}
+{{- if eq $scheme "https" -}}
+{{- printf "%s://%s:91" $scheme $host -}}
+{{- else -}}
+{{- printf "%s://%s:90" $scheme $host -}}
+{{- end -}}
+{{- end }}
 
 
 {{- define "regionRepositoryMap" -}}

--- a/incubator/opentelemetry-operator/templates/clusterrole.yaml
+++ b/incubator/opentelemetry-operator/templates/clusterrole.yaml
@@ -151,6 +151,8 @@ rules:
     resources:
       - instrumentations
     verbs:
+      - create
+      - delete
       - get
       - list
       - patch
@@ -183,26 +185,26 @@ rules:
       - patch
       - update
   - apiGroups:
-    - route.openshift.io
+      - route.openshift.io
     resources:
-    - routes
-    - routes/custom-host
+      - routes
+      - routes/custom-host
     verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
-    - discovery.k8s.io
+      - discovery.k8s.io
     resources:
-    - endpointslices
+      - endpointslices
     verbs:
-    - get
-    - list
-    - watch
+      - get
+      - list
+      - watch
 
 {{ if .Values.kubeRBACProxy.enabled }}
 ---

--- a/incubator/opentelemetry-operator/templates/deployment.yaml
+++ b/incubator/opentelemetry-operator/templates/deployment.yaml
@@ -128,6 +128,18 @@ spec:
               name: webhook-server
               protocol: TCP
             {{- end }}
+          {{- if or .Values.admissionWebhooks.create .Values.admissionWebhooks.secretName }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.manager.ports.webhookPort }}
+              scheme: HTTPS
+            initialDelaySeconds: 7
+            periodSeconds: 3
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 20
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/incubator/opentelemetry-operator/templates/instrumentation.yaml
+++ b/incubator/opentelemetry-operator/templates/instrumentation.yaml
@@ -1,35 +1,7 @@
-apiVersion: opentelemetry.io/v1alpha1
-kind: Instrumentation
-metadata:
-  name: default-instrumentation
-  namespace: opentelemetry-operator-system
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-spec:
-  exporter:
-    endpoint: {{.Values.env.ENDPOINT | quote | trim}}
-  propagators:
-    - tracecontext
-    - baggage
-    - b3
-  resource:
-    resourceAttributes:
-      token: {{.Values.env.APM_TOKEN}}
-  java:
-    image:
-  nodejs:
-    image:
-  python:
-    image:
-    env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: {{printf "%s/otlp" (include "opentelemetry-operator.host" . ) | quote | trim}}
-  dotnet:
-    image:
-    env:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: {{printf "%s/otlp" (include "opentelemetry-operator.host" . ) | quote | trim}}
-  go:
-    image: ccr.ccs.tencentyun.com/tapm/autoinstrumentation-go:v0.8.0-alpha
+{{- /*
+  此文件仅作为模板参考，实际的 Instrumentation 资源，由 waitformanagerjob.yaml 中的 Job 在确认 Operator 就绪后创建。
+  如需直接通过 Helm hook 创建，设置 .Values.instrumentation.createDirectly = true
+*/ -}}
+{{- if (.Values.env.DIRECTLY_CREATE_INSTRUMENTATION | default false) }}
+{{ include "opentelemetry-operator.instrumentation" . }}
+{{- end }}

--- a/incubator/opentelemetry-operator/templates/instrumentation.yaml
+++ b/incubator/opentelemetry-operator/templates/instrumentation.yaml
@@ -3,6 +3,10 @@ kind: Instrumentation
 metadata:
   name: default-instrumentation
   namespace: opentelemetry-operator-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   exporter:
     endpoint: {{.Values.env.ENDPOINT | quote | trim}}

--- a/incubator/opentelemetry-operator/templates/instrumentation.yaml
+++ b/incubator/opentelemetry-operator/templates/instrumentation.yaml
@@ -21,11 +21,11 @@ spec:
     image:
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: {{printf "%s:90/otlp" (include "opentelemetry-operator.host" . ) | quote | trim}}
+        value: {{printf "%s/otlp" (include "opentelemetry-operator.host" . ) | quote | trim}}
   dotnet:
     image:
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: {{printf "%s:90/otlp" (include "opentelemetry-operator.host" . ) | quote | trim}}
+        value: {{printf "%s/otlp" (include "opentelemetry-operator.host" . ) | quote | trim}}
   go:
     image: ccr.ccs.tencentyun.com/tapm/autoinstrumentation-go:v0.8.0-alpha

--- a/incubator/opentelemetry-operator/templates/waitformanagerjob.yaml
+++ b/incubator/opentelemetry-operator/templates/waitformanagerjob.yaml
@@ -1,0 +1,178 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "opentelemetry-operator.fullname" . }}-wait-for-manager
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  labels:
+    {{- include "opentelemetry-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: wait-for-manager
+spec:
+  backoffLimit: 10
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      name: {{ template "opentelemetry-operator.fullname" . }}-wait-for-manager
+      labels:
+        {{- include "opentelemetry-operator.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: wait-for-manager
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "opentelemetry-operator.serviceAccountName" . }}
+      containers:
+        - name: wait-for-manager
+          image: "{{ .Values.waitForManager.image.repository }}:{{ .Values.waitForManager.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          {{- with .Values.waitForManager.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              DEPLOYMENT_NAME="{{ template "opentelemetry-operator.fullname" . }}"
+              NAMESPACE="{{ .Release.Namespace }}"
+              MAX_RETRIES=60
+              RETRY_INTERVAL=3
+
+              echo "==========================================="
+              echo "等待 OpenTelemetry Operator Manager 就绪"
+              echo "==========================================="
+              echo "Deployment: ${DEPLOYMENT_NAME}"
+              echo "Namespace: ${NAMESPACE}"
+              echo "最大重试次数: ${MAX_RETRIES}"
+              echo "重试间隔: ${RETRY_INTERVAL}秒"
+              echo ""
+
+              echo "正在检查 Deployment 是否存在..."
+              retry_count=0
+              while [ $retry_count -lt $MAX_RETRIES ]; do
+                if kubectl get deployment "${DEPLOYMENT_NAME}" -n "${NAMESPACE}" > /dev/null 2>&1; then
+                  echo "✓ Deployment 已存在"
+                  break
+                fi
+                retry_count=$((retry_count + 1))
+                echo "Deployment 尚未创建，等待中... (${retry_count}/${MAX_RETRIES})"
+                sleep ${RETRY_INTERVAL}
+              done
+
+              if [ $retry_count -ge $MAX_RETRIES ]; then
+                echo "✗ 错误: Deployment 在超时时间内未创建"
+                exit 1
+              fi
+
+
+              echo ""
+              echo "正在等待 Deployment available 状态..."
+              echo ""
+              kubectl get deployment "${DEPLOYMENT_NAME}" -n "${NAMESPACE}" -o wide || true
+
+              if kubectl wait --for=condition=available \
+                --timeout=120s \
+                deployment/"${DEPLOYMENT_NAME}" \
+                -n "${NAMESPACE}"; then
+                echo ""
+                echo "==========================================="
+                echo "✓ Manager 已就绪 (包括 webhook server)"
+                echo "==========================================="
+
+                kubectl get deployment "${DEPLOYMENT_NAME}" -n "${NAMESPACE}" -o wide || true
+
+                echo ""
+
+                # 使用 base64 编码传递 YAML 内容 (避免 Shell 解析问题)
+                INSTRUMENTATION_YAML_B64='{{ include "opentelemetry-operator.instrumentation" . | b64enc }}'
+
+                echo "Instrumentation.yaml文件内容如下"
+                echo "${INSTRUMENTATION_YAML_B64}" | base64 -d
+                echo ""
+
+                echo "准备安装Instrumentation资源 (超时时间: 30秒)"
+                echo "开始时间: $(date '+%Y-%m-%d %H:%M:%S')"
+                echo ""
+
+                # 纯管道 + 变量捕获方式，不依赖文件系统写入
+                TIMEOUT_SECONDS=60
+
+                # 后台执行 kubectl apply，并通过变量传递 PID
+                echo "${INSTRUMENTATION_YAML_B64}" | base64 -d | kubectl apply -f - 2>&1 &
+                KUBECTL_PID=$!
+                echo "kubectl apply 进程已启动 PID: ${KUBECTL_PID}"
+
+                # 超时监控循环
+                ELAPSED=0
+                APPLY_EXIT_CODE=""
+                while [ ${ELAPSED} -lt ${TIMEOUT_SECONDS} ]; do
+                  if ! kill -0 ${KUBECTL_PID} 2>/dev/null; then
+                    # kubectl 进程已完成，获取退出码
+                    wait ${KUBECTL_PID}
+                    APPLY_EXIT_CODE=$?
+                    echo "kubectl apply 进程已完成 (耗时: ${ELAPSED}秒)"
+                    break
+                  fi
+                  sleep 1
+                  ELAPSED=$((ELAPSED + 1))
+                  # 每 10 秒输出等待信息
+                  if [ $((ELAPSED % 10)) -eq 0 ]; then
+                    echo "[${ELAPSED}秒] 仍在等待 kubectl apply 完成..."
+                  fi
+                done
+
+                # 检查是否超时
+                if [ -z "${APPLY_EXIT_CODE}" ]; then
+                  echo ""
+                  echo "✗ kubectl apply 超时 (${TIMEOUT_SECONDS}秒)，强制终止进程..."
+                  kill -9 ${KUBECTL_PID} 2>/dev/null || true
+                  wait ${KUBECTL_PID} 2>/dev/null || true
+                  APPLY_EXIT_CODE=124
+                fi
+
+                echo ""
+                echo "结束时间: $(date '+%Y-%m-%d %H:%M:%S')"
+                echo "Instrumentation资源安装结束，退出码: ${APPLY_EXIT_CODE}"
+
+                if [ ${APPLY_EXIT_CODE} -eq 0 ]; then
+                  echo "✓ Instrumentation 资源创建成功"
+                  echo ""
+                  echo "==========================================="
+                  echo "✓ 所有资源已就绪"
+                  echo "==========================================="
+                  exit 0
+                else
+                  echo "✗ Instrumentation 资源创建失败，退出码: ${APPLY_EXIT_CODE}"
+                  exit 1
+                fi
+              else
+                echo ""
+                echo "==========================================="
+                echo "✗ 错误: Manager 未能在超时时间内就绪"
+                echo "==========================================="
+                # 打印 Deployment 状态以便调试
+                echo "当前 Deployment 状态:"
+                kubectl get deployment "${DEPLOYMENT_NAME}" -n "${NAMESPACE}" -o wide || true
+                echo ""
+                echo "Pod 状态:"
+                kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/name={{ include "opentelemetry-operator.name" . }} -o wide || true
+                exit 1
+              fi
+          securityContext:
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -29,7 +29,7 @@ pdb:
 manager:
   image:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-operator
-    tag: 20250912-1437_apm_0.91.0_auto_f5c0be5f
+    tag: 20251216-1547_apm_0.91.2_auto_d275af46
   collectorImage:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-collector-contrib
     tag: 0.85.0
@@ -89,7 +89,7 @@ manager:
     # add annotations on the ServiceMonitor
     annotations: {}
     metricsEndpoints:
-    - port: metrics
+      - port: metrics
 
   podAnnotations: {}
   podLabels: {}
@@ -146,7 +146,7 @@ manager:
     # allowPrivilegeEscalation: false
     # capabilities:
     #   drop:
-    #   - ALL
+  #   - ALL
 
 ## Provide OpenTelemetry Operator kube-rbac-proxy container image.
 ##
@@ -175,7 +175,21 @@ kubeRBACProxy:
     # allowPrivilegeEscalation: false
     # capabilities:
     #   drop:
-    #   - ALL
+  #   - ALL
+
+## Provide wait-for-manager Job container image and resources.
+##
+waitForManager:
+  image:
+    repository: ccr.ccs.tencentyun.com/tke-market/kubectl
+    tag: v1.35.0
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
 
 ## Admission webhooks make sure only requests with correctly formatted rules will get into the Operator.
 ## They also enable the sidecar injection for OpenTelemetryCollector and Instrumentation CR's
@@ -210,7 +224,7 @@ admissionWebhooks:
     ## By default, OpenTelemetry Operator will use self-signer issuer.
     issuerRef: {}
       # kind:
-      # name:
+    # name:
     ## Annotations for the cert and issuer if cert-manager is enabled.
     certificateAnnotations: {}
     issuerAnnotations: {}
@@ -287,6 +301,9 @@ env:
 
   ## Optional, default "false"; Set to "true" for integrating with APM service via internet endpoint
   FROM_INTERNET: "false"
+
+  ## Optional, default false; Set to true for directly creating instrumentation by helm.
+  DIRECTLY_CREATE_INSTRUMENTATION: false
 
 config:
   "java": "bwiefeunq4+28k5omTkgc3XQLHjDEh4aylntxj4NiVRsibnL5n4Kk0EHTYJPoXHe"

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -29,7 +29,7 @@ pdb:
 manager:
   image:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-operator
-    tag: 20251216-1547_apm_0.91.2_auto_d275af46
+    tag: v0.91.2
   collectorImage:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-collector-contrib
     tag: 0.85.0


### PR DESCRIPTION
tencent-opentelemetry-operator 0.91.2版本更新

变更点：
* 支持https协议上报
* 适配helm-cli3.x和helm-cli4.x资源安装顺序
* 支持arm64的机器运行operator