### PR TITLE
upgrade tencent-opentelemetry-operator to 0.92.0

### DIFF
--- a/incubator/opentelemetry-operator/Chart.yaml
+++ b/incubator/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tencent-opentelemetry-operator
-version: 0.91.2
+version: 0.92.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -9,5 +9,5 @@ sources:
 maintainers:
   - name: erichchen
 icon: https://cloudcache.tencent-cloud.com/qcloud/ui/static/Industry_tke/80444e53-c142-4896-bc8a-ef4ecf75c682.png
-appVersion: v0.91.2
+appVersion: v0.92.0
 kubeVersion: '>= 1.19.0-0'

--- a/incubator/opentelemetry-operator/templates/deployment.yaml
+++ b/incubator/opentelemetry-operator/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
             - name: ENDPOINT
               value: {{ .Values.env.ENDPOINT | quote }}
             - name: API_REGION
-              value: {{ .Values.env.API_REGION | quote }}
+              value: {{ include "opentelemetry-operator.apiRegion" . | quote }}
             - name: JAVA_INSTR_VERSION
               value: {{ .Values.env.JAVA_INSTR_VERSION | quote }}
             - name: PYTHON_INSTR_VERSION

--- a/incubator/opentelemetry-operator/templates/waitformanagerjob.yaml
+++ b/incubator/opentelemetry-operator/templates/waitformanagerjob.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: {{ template "opentelemetry-operator.serviceAccountName" . }}
       containers:
         - name: wait-for-manager
-          image: "{{ .Values.waitForManager.image.repository }}:{{ .Values.waitForManager.image.tag }}"
+          image: "{{ include "opentelemetry-operator.jobImageRepository" . }}:{{ .Values.waitForManager.image.tag }}"
           imagePullPolicy: IfNotPresent
           {{- with .Values.waitForManager.resources }}
           resources: {{- toYaml . | nindent 12 }}

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -28,8 +28,7 @@ pdb:
 ##
 manager:
   image:
-#    repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-operator
-    repository: ccr.ccs.tencentyun.com/tapm/opentelemetry-operator
+    repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-operator
     tag: v0.92.0
   collectorImage:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-collector-contrib

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -28,8 +28,9 @@ pdb:
 ##
 manager:
   image:
-    repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-operator
-    tag: v0.91.2
+#    repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-operator
+    repository: ccr.ccs.tencentyun.com/tapm/opentelemetry-operator
+    tag: v0.92.0
   collectorImage:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-collector-contrib
     tag: 0.85.0
@@ -287,8 +288,6 @@ env:
   ## Required, obtained from the apm console
   APM_TOKEN: ""
   ENDPOINT: ""
-  API_REGION: ""
-
 
   ## Optional, default latest; If you want to specify the version, you can get it from the apm documentation
   JAVA_INSTR_VERSION: "latest"
@@ -301,9 +300,6 @@ env:
 
   ## Optional, default "false"; Set to "true" for integrating with APM service via internet endpoint
   FROM_INTERNET: "false"
-
-  ## Optional, default false; Set to true for directly creating instrumentation by helm.
-  DIRECTLY_CREATE_INSTRUMENTATION: false
 
 config:
   "java": "bwiefeunq4+28k5omTkgc3XQLHjDEh4aylntxj4NiVRsibnL5n4Kk0EHTYJPoXHe"


### PR DESCRIPTION
主要变更点：
1. 更新operator镜像版本为v0.92.0,支持namespace级别的注释
2. API_REGION环境变量能够根据ENDPOINT值进行填充
3. 修复waitformanagerjob使用的kubectl镜像地址渲染错误的问题