### PR TITLE
feat: 升级 Chart 版本为 v0.92.2，变更内部引用的镜像版本

### DIFF
--- a/incubator/opentelemetry-operator/Chart.yaml
+++ b/incubator/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tencent-opentelemetry-operator
-version: 0.92.1
+version: 0.92.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -10,5 +10,5 @@ maintainers:
   - name: nevanwang
     email: nevanwang@tencent.com
 icon: https://cloudcache.tencent-cloud.com/qcloud/ui/static/Industry_tke/80444e53-c142-4896-bc8a-ef4ecf75c682.png
-appVersion: v0.92.1
+appVersion: v0.92.2
 kubeVersion: '>= 1.19.0-0'

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -29,7 +29,7 @@ pdb:
 manager:
   image:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-operator
-    tag: v0.92.1
+    tag: v0.92.2
   collectorImage:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-collector-contrib
     tag: 0.85.0


### PR DESCRIPTION
1. 通过 cloud.tencent.com/service-tags 注解注入应用标签，废弃原先环境变量 SERVICE_TAGS 的形式
2. 提供通过 labels 的方式注入java探针