### PR TITLE
opentelemetry operator chart 发布0.93.0 

### DIFF
--- a/incubator/opentelemetry-operator/Chart.yaml
+++ b/incubator/opentelemetry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tencent-opentelemetry-operator
-version: 0.92.4
+version: 0.93.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -10,5 +10,5 @@ maintainers:
   - name: nevanwang
     email: nevanwang@tencent.com
 icon: https://cloudcache.tencent-cloud.com/qcloud/ui/static/Industry_tke/80444e53-c142-4896-bc8a-ef4ecf75c682.png
-appVersion: v0.92.5
+appVersion: v0.93.0
 kubeVersion: '>= 1.19.0-0'

--- a/incubator/opentelemetry-operator/templates/_helpers.tpl
+++ b/incubator/opentelemetry-operator/templates/_helpers.tpl
@@ -370,6 +370,4 @@ spec:
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: {{ printf "%s/otlp" (include "opentelemetry-operator.host" . ) | quote | trim }}
-  go:
-    image: ccr.ccs.tencentyun.com/tapm/autoinstrumentation-go:v0.8.0-alpha
 {{- end -}}

--- a/incubator/opentelemetry-operator/templates/_helpers.tpl
+++ b/incubator/opentelemetry-operator/templates/_helpers.tpl
@@ -341,17 +341,6 @@ Instrumentation resource spec definition.
 用于在多个地方复用 Instrumentation 资源定义
 */}}
 {{- define "opentelemetry-operator.instrumentation" -}}
-{{- $registry := "" -}}
-{{- if and (ne .Values.env.INSTR_REPOSITORY "") (ne .Values.env.INSTR_REPOSITORY "ccr.ccs.tencentyun.com/tapm") -}}
-{{- $registry = .Values.env.INSTR_REPOSITORY -}}
-{{- else -}}
-{{- $registry = include "regionRepositoryMap" .Values.env.TKE_REGION -}}
-{{- $registry = printf "%s/tapm" $registry -}}
-{{- end -}}
-{{- $javaVersion := ternary "2.11-20260228" .Values.env.JAVA_INSTR_VERSION (eq .Values.env.JAVA_INSTR_VERSION "latest") -}}
-{{- $nodejsVersion := ternary "0.51.0" .Values.env.NODEJS_INSTR_VERSION (eq .Values.env.NODEJS_INSTR_VERSION "latest") -}}
-{{- $pythonVersion := ternary "0.58b0" .Values.env.PYTHON_INSTR_VERSION (eq .Values.env.PYTHON_INSTR_VERSION "latest") -}}
-{{- $dotnetVersion := ternary "1.10.0" .Values.env.DOTNET_INSTR_VERSION (eq .Values.env.DOTNET_INSTR_VERSION "latest") -}}
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
@@ -368,16 +357,16 @@ spec:
     resourceAttributes:
       token: {{ .Values.env.APM_TOKEN }}
   java:
-    image: {{ printf "%s/opentelemetry-java-agent:%s" $registry $javaVersion }}
+    image: ""
   nodejs:
-    image: {{ printf "%s/autoinstrumentation-nodejs:%s" $registry $nodejsVersion }}
+    image: ""
   python:
-    image: {{ printf "%s/autoinstrumentation-python:%s" $registry $pythonVersion }}
+    image: ""
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: {{ printf "%s/otlp" (include "opentelemetry-operator.host" . ) | quote | trim }}
   dotnet:
-    image: {{ printf "%s/autoinstrumentation-dotnet:%s" $registry $dotnetVersion }}
+    image: ""
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: {{ printf "%s/otlp" (include "opentelemetry-operator.host" . ) | quote | trim }}

--- a/incubator/opentelemetry-operator/templates/deployment.yaml
+++ b/incubator/opentelemetry-operator/templates/deployment.yaml
@@ -103,6 +103,10 @@ spec:
               value: {{ .Values.env.DOTNET_INSTR_VERSION | quote }}
             - name: NODEJS_INSTR_VERSION
               value: {{ .Values.env.NODEJS_INSTR_VERSION | quote }}
+            - name: JAVA_INSTR_NACOS_SERVER
+              value: {{ .Values.env.JAVA_INSTR_NACOS_SERVER | quote }}
+            - name: JAVA_INSTR_ARTHAS_URL
+              value: {{ .Values.env.JAVA_INSTR_ARTHAS_URL | quote }}
             - name: INTL_SITE
               value: {{ .Values.env.INTL_SITE | quote }}
             - name: CONFIG_JAVA

--- a/incubator/opentelemetry-operator/templates/deployment.yaml
+++ b/incubator/opentelemetry-operator/templates/deployment.yaml
@@ -81,10 +81,6 @@ spec:
             - name: {{ $name }}
               value: {{ $value | quote -}}
             {{- end }}
-            {{- if (eq .Values.env.FROM_INTERNET "true") }}
-            - name: API_ENDPOINT
-              value: "apm.tencentcloudapi.com"
-            {{- end }}
             - name: TKE_CLUSTER_ID
               value: {{ .Values.env.TKE_CLUSTER_ID | quote }}
             - name: TKE_REGION
@@ -107,8 +103,13 @@ spec:
               value: {{ .Values.env.JAVA_INSTR_NACOS_SERVER | quote }}
             - name: JAVA_INSTR_ARTHAS_URL
               value: {{ .Values.env.JAVA_INSTR_ARTHAS_URL | quote }}
+            {{- if ne (toString .Values.env.API_ENDPOINT) "" }}
             - name: API_ENDPOINT
               value: {{ .Values.env.API_ENDPOINT | quote }}
+            {{- else if eq (toString .Values.env.FROM_INTERNET) "true" }}
+            - name: API_ENDPOINT
+              value: "apm.tencentcloudapi.com"
+            {{- end }}
             - name: INTL_SITE
               value: {{ .Values.env.INTL_SITE | quote }}
             - name: CONFIG_JAVA

--- a/incubator/opentelemetry-operator/templates/deployment.yaml
+++ b/incubator/opentelemetry-operator/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
               value: {{ .Values.env.JAVA_INSTR_NACOS_SERVER | quote }}
             - name: JAVA_INSTR_ARTHAS_URL
               value: {{ .Values.env.JAVA_INSTR_ARTHAS_URL | quote }}
+            - name: API_ENDPOINT
+              value: {{ .Values.env.API_ENDPOINT | quote }}
             - name: INTL_SITE
               value: {{ .Values.env.INTL_SITE | quote }}
             - name: CONFIG_JAVA

--- a/incubator/opentelemetry-operator/templates/deployment.yaml
+++ b/incubator/opentelemetry-operator/templates/deployment.yaml
@@ -67,9 +67,6 @@ spec:
             {{- if and .Values.manager.autoInstrumentationImage.dotnet.repository .Values.manager.autoInstrumentationImage.dotnet.tag }}
             - --auto-instrumentation-dotnet-image={{ .Values.manager.autoInstrumentationImage.dotnet.repository }}:{{ .Values.manager.autoInstrumentationImage.dotnet.tag }}
             {{- end }}
-            {{- if and .Values.manager.autoInstrumentationImage.go.repository .Values.manager.autoInstrumentationImage.go.tag }}
-            - --auto-instrumentation-go-image={{ .Values.manager.autoInstrumentationImage.go.repository }}:{{ .Values.manager.autoInstrumentationImage.go.tag }}
-            {{- end }}
             {{- if .Values.manager.featureGates }}
             - --feature-gates={{ .Values.manager.featureGates }}
             {{- end }}

--- a/incubator/opentelemetry-operator/templates/deployment.yaml
+++ b/incubator/opentelemetry-operator/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               {{- else }}
               value: {{ .Values.env.INSTR_IMAGE_REPOSITORY | quote }}
               {{- end }}
+            - name: IMAGE_NAMESPACE
+              value: {{ .Values.env.INSTR_IMAGE_NAMESPACE | default "tapm" | quote }}
           {{- end }}
           image: "{{ include "opentelemetry-operator.managerImageRepository" . }}:{{ .Values.manager.image.tag }}"
           name: manager

--- a/incubator/opentelemetry-operator/templates/deployment.yaml
+++ b/incubator/opentelemetry-operator/templates/deployment.yaml
@@ -122,7 +122,11 @@ spec:
             - name: HELM_CHART_VERSION
               value: {{ .Chart.Version | quote }}
             - name: IMAGE_REPOSITORY
+              {{- if or (eq (toString .Values.env.INSTR_IMAGE_REPOSITORY) "") (eq (toString .Values.env.INSTR_IMAGE_REPOSITORY) "ccr.ccs.tencentyun.com") }}
               value: {{ include "regionRepositoryMap" .Values.env.TKE_REGION | default (include "regionRepositoryMap" "ap-guangzhou") | quote }}
+              {{- else }}
+              value: {{ .Values.env.INSTR_IMAGE_REPOSITORY | quote }}
+              {{- end }}
           {{- end }}
           image: "{{ include "opentelemetry-operator.managerImageRepository" . }}:{{ .Values.manager.image.tag }}"
           name: manager

--- a/incubator/opentelemetry-operator/values.schema.json
+++ b/incubator/opentelemetry-operator/values.schema.json
@@ -344,37 +344,6 @@
                                 "repository": "",
                                 "tag": ""
                             }]
-                        },
-                        "go": {
-                            "type": "object",
-                            "default": {},
-                            "title": "The Go Schema",
-                            "required": [
-                                "repository",
-                                "tag"
-                            ],
-                            "properties": {
-                                "repository": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The repository Schema",
-                                    "examples": [
-                                        ""
-                                    ]
-                                },
-                                "tag": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The tag Schema",
-                                    "examples": [
-                                        ""
-                                    ]
-                                }
-                            },
-                            "examples": [{
-                                "repository": "",
-                                "tag": ""
-                            }]
                         }
                     },
                     "examples": [{
@@ -398,10 +367,10 @@
                 },
                 "featureGates": {
                     "type": "string",
-                    "default": "operator.autoinstrumentation.go",
+                    "default": "",
                     "title": "The featureGates Schema",
                     "examples": [
-                        "-operator.autoinstrumentation.go,-operator.autoinstrumentation.go"
+                        ""
                     ]
                 },
                 "ports": {
@@ -903,10 +872,6 @@
                         "tag": ""
                     },
                     "dotnet": {
-                        "repository": "",
-                        "tag": ""
-                    },
-                    "go": {
                         "repository": "",
                         "tag": ""
                     }

--- a/incubator/opentelemetry-operator/values.schema.json
+++ b/incubator/opentelemetry-operator/values.schema.json
@@ -21,7 +21,8 @@
         "hostNetwork",
         "priorityClassName",
         "securityContext",
-        "testFramework"
+        "testFramework",
+        "env"
     ],
     "properties": {
         "replicaCount": {
@@ -1519,6 +1520,141 @@
                     "tag": "latest"
                 }
             }]
+        },
+        "env": {
+            "type": "object",
+            "default": {},
+            "title": "The env Schema",
+            "required": [
+                "TKE_CLUSTER_ID",
+                "TKE_REGION",
+                "APM_TOKEN",
+                "ENDPOINT"
+            ],
+            "properties": {
+                "TKE_CLUSTER_ID": {
+                    "type": "string",
+                    "default": "",
+                    "title": "TKE Cluster ID",
+                    "description": "Required, obtained from the TKE console. For non-TKE users, enter 'N/A'",
+                    "examples": [""]
+                },
+                "TKE_REGION": {
+                    "type": "string",
+                    "default": "",
+                    "title": "TKE Region",
+                    "description": "Required, obtained from the TKE console. For non-TKE users, enter 'N/A'",
+                    "examples": ["ap-guangzhou"]
+                },
+                "APM_TOKEN": {
+                    "type": "string",
+                    "default": "",
+                    "title": "APM Token",
+                    "description": "Required, obtained from the APM console",
+                    "examples": [""]
+                },
+                "ENDPOINT": {
+                    "type": "string",
+                    "default": "",
+                    "title": "APM Endpoint",
+                    "description": "Required, obtained from the APM console",
+                    "examples": [""]
+                },
+                "INSTR_IMAGE_REPOSITORY": {
+                    "type": "string",
+                    "default": "ccr.ccs.tencentyun.com",
+                    "title": "Instrumentation Image Repository",
+                    "description": "Optional, specify the image repository for instrumentation images",
+                    "examples": ["ccr.ccs.tencentyun.com"]
+                },
+                "INSTR_IMAGE_NAMESPACE": {
+                    "type": "string",
+                    "default": "tapm",
+                    "title": "Instrumentation Image Namespace",
+                    "description": "Optional, specify the image namespace for instrumentation images",
+                    "examples": ["tapm"]
+                },
+                "JAVA_INSTR_VERSION": {
+                    "type": "string",
+                    "default": "latest",
+                    "title": "Java Instrumentation Version",
+                    "description": "Optional, specify the Java instrumentation image version",
+                    "examples": ["latest"]
+                },
+                "PYTHON_INSTR_VERSION": {
+                    "type": "string",
+                    "default": "latest",
+                    "title": "Python Instrumentation Version",
+                    "description": "Optional, specify the Python instrumentation image version",
+                    "examples": ["latest"]
+                },
+                "DOTNET_INSTR_VERSION": {
+                    "type": "string",
+                    "default": "latest",
+                    "title": "DotNet Instrumentation Version",
+                    "description": "Optional, specify the .NET instrumentation image version",
+                    "examples": ["latest"]
+                },
+                "NODEJS_INSTR_VERSION": {
+                    "type": "string",
+                    "default": "latest",
+                    "title": "NodeJS Instrumentation Version",
+                    "description": "Optional, specify the Node.js instrumentation image version",
+                    "examples": ["latest"]
+                },
+                "JAVA_INSTR_NACOS_SERVER": {
+                    "type": "string",
+                    "default": "",
+                    "title": "Java Instrumentation Nacos Server",
+                    "description": "Optional, specify the Nacos server address for Java instrumentation",
+                    "examples": [""]
+                },
+                "JAVA_INSTR_ARTHAS_URL": {
+                    "type": "string",
+                    "default": "",
+                    "title": "Java Instrumentation Arthas URL",
+                    "description": "Optional, specify the Arthas URL for Java instrumentation",
+                    "examples": [""]
+                },
+                "API_ENDPOINT": {
+                    "type": "string",
+                    "default": "",
+                    "title": "API Endpoint",
+                    "description": "Optional, specify the yun api server address",
+                    "examples": [""]
+                },
+                "INTL_SITE": {
+                    "type": "string",
+                    "default": "false",
+                    "title": "International Site",
+                    "description": "Optional, set to 'true' for international users",
+                    "examples": ["false"]
+                },
+                "FROM_INTERNET": {
+                    "type": "string",
+                    "default": "false",
+                    "title": "From Internet",
+                    "description": "Optional, set to 'true' for integrating with APM service via internet endpoint",
+                    "examples": ["false"]
+                }
+            },
+            "examples": [{
+                "TKE_CLUSTER_ID": "",
+                "TKE_REGION": "",
+                "APM_TOKEN": "",
+                "ENDPOINT": "",
+                "INSTR_IMAGE_REPOSITORY": "ccr.ccs.tencentyun.com",
+                "INSTR_IMAGE_NAMESPACE": "tapm",
+                "JAVA_INSTR_VERSION": "latest",
+                "PYTHON_INSTR_VERSION": "latest",
+                "DOTNET_INSTR_VERSION": "latest",
+                "NODEJS_INSTR_VERSION": "latest",
+                "JAVA_INSTR_NACOS_SERVER": "",
+                "JAVA_INSTR_ARTHAS_URL": "",
+                "API_ENDPOINT": "",
+                "INTL_SITE": "false",
+                "FROM_INTERNET": "false"
+            }]
         }
     },
     "examples": [{
@@ -1682,6 +1818,23 @@
                 "repository": "busybox",
                 "tag": "latest"
             }
+        },
+        "env": {
+            "TKE_CLUSTER_ID": "",
+            "TKE_REGION": "",
+            "APM_TOKEN": "",
+            "ENDPOINT": "",
+            "INSTR_IMAGE_REPOSITORY": "ccr.ccs.tencentyun.com",
+            "INSTR_IMAGE_NAMESPACE": "tapm",
+            "JAVA_INSTR_VERSION": "latest",
+            "PYTHON_INSTR_VERSION": "latest",
+            "DOTNET_INSTR_VERSION": "latest",
+            "NODEJS_INSTR_VERSION": "latest",
+            "JAVA_INSTR_NACOS_SERVER": "",
+            "JAVA_INSTR_ARTHAS_URL": "",
+            "API_ENDPOINT": "",
+            "INTL_SITE": "false",
+            "FROM_INTERNET": "false"
         }
     }]
 }

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -29,7 +29,7 @@ pdb:
 manager:
   image:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-operator
-    tag: v0.92.5
+    tag: v0.93.0
   collectorImage:
     repository: ccr.ccs.tencentyun.com/tke-market/opentelemetry-collector-contrib
     tag: 0.85.0
@@ -39,7 +39,7 @@ manager:
   autoInstrumentationImage:
     java:
       repository: "ccr.ccs.tencentyun.com/tapm/opentelemetry-java-agent"
-      tag: "2.11-20260228"
+      tag: "2.11-20260430"
     nodejs:
       repository: "ccr.ccs.tencentyun.com/tapm/autoinstrumentation-nodejs"
       tag: "0.51.0"
@@ -301,11 +301,8 @@ env:
   JAVA_INSTR_NACOS_SERVER: ""
   ## Optional, specify the Arthas URL
   JAVA_INSTR_ARTHAS_URL: ""
-
-
   ## Optional, default "false"; Set to "true" for international users
   INTL_SITE: "false"
-
   ## Optional, default "false"; Set to "true" for integrating with APM service via internet endpoint
   FROM_INTERNET: "false"
 

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -38,22 +38,17 @@ manager:
     tag: ""
   autoInstrumentationImage:
     java:
-      repository: ""
-      tag: ""
+      repository: "ccr.ccs.tencentyun.com/tapm/opentelemetry-java-agent"
+      tag: "2.11-20260228"
     nodejs:
-      repository: ""
-      tag: ""
+      repository: "ccr.ccs.tencentyun.com/tapm/autoinstrumentation-nodejs"
+      tag: "0.51.0"
     python:
-      repository: ""
-      tag: ""
+      repository: "ccr.ccs.tencentyun.com/tapm/autoinstrumentation-python"
+      tag: "0.58b0"
     dotnet:
-      repository: ""
-      tag: ""
-    # The Go instrumentaiton support in the operator is disabled by default.
-    # To enable it, use the operator.autoinstrumentation.go feature gate.
-    go:
-      repository: ""
-      tag: ""
+      repository: "ccr.ccs.tencentyun.com/tapm/autoinstrumentation-dotnet"
+      tag: "1.10.0"
   # Feature Gates are a a comma-delimited list of feature gate identifiers.
   # Prefix a gate with '-' to disable support.
   # Prefixing a gate with '+' or no prefix will enable support.
@@ -295,11 +290,16 @@ env:
   ENDPOINT: ""
 
   ## Optional, specify the image repository and image version;
-  INSTR_REPOSITORY: "ccr.ccs.tencentyun.com/tapm"
   JAVA_INSTR_VERSION: "latest"
   PYTHON_INSTR_VERSION: "latest"
   DOTNET_INSTR_VERSION: "latest"
   NODEJS_INSTR_VERSION: "latest"
+
+  ## Optional, specify the Nacos server address
+  JAVA_INSTR_NACOS_SERVER: ""
+  ## Optional, specify the Arthas URL
+  JAVA_INSTR_ARTHAS_URL: ""
+
 
   ## Optional, default "false"; Set to "true" for international users
   INTL_SITE: "false"

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -290,6 +290,7 @@ env:
   ENDPOINT: ""
 
   ## Optional, specify the image repository and image version;
+  INSTR_IMAGE_REPOSITORY: "ccr.ccs.tencentyun.com"
   JAVA_INSTR_VERSION: "latest"
   PYTHON_INSTR_VERSION: "latest"
   DOTNET_INSTR_VERSION: "latest"

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -291,6 +291,7 @@ env:
 
   ## Optional, specify the image repository and image version;
   INSTR_IMAGE_REPOSITORY: "ccr.ccs.tencentyun.com"
+  INSTR_IMAGE_NAMESPACE: "tapm"
   JAVA_INSTR_VERSION: "latest"
   PYTHON_INSTR_VERSION: "latest"
   DOTNET_INSTR_VERSION: "latest"

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -301,6 +301,8 @@ env:
   JAVA_INSTR_NACOS_SERVER: ""
   ## Optional, specify the Arthas URL
   JAVA_INSTR_ARTHAS_URL: ""
+  ## Optional, specify the yun api server address
+  API_ENDPOINT: ""
   ## Optional, default "false"; Set to "true" for international users
   INTL_SITE: "false"
   ## Optional, default "false"; Set to "true" for integrating with APM service via internet endpoint

--- a/incubator/opentelemetry-operator/values.yaml
+++ b/incubator/opentelemetry-operator/values.yaml
@@ -53,7 +53,7 @@ manager:
   # Prefix a gate with '-' to disable support.
   # Prefixing a gate with '+' or no prefix will enable support.
   # A full list of valud identifiers can be found here: https://github.com/open-telemetry/opentelemetry-operator/blob/main/pkg/featuregate/featuregate.go
-  featureGates: "operator.autoinstrumentation.go"
+  featureGates: ""
   ports:
     metricsPort: 8080
     webhookPort: 9443


### PR DESCRIPTION
1. 支持java语言，nacos和arthas环境变量的注入
2. 更改默认兜底镜像的渲染规则，支持私有镜像仓库