### PR TITLE
chore(tke-extend-network-controller): 同步 v2.4.2 变更

### DIFF
--- a/incubator/tke-extend-network-controller/Chart.yaml
+++ b/incubator/tke-extend-network-controller/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.1
+version: 2.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2.4.1
+appVersion: 2.4.2
 kubeVersion: '>= 1.26.0-0'

--- a/incubator/tke-extend-network-controller/templates/deployment.yaml
+++ b/incubator/tke-extend-network-controller/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       - hostnames:
         - clb.tencentcloudapi.com
         - vpc.tencentcloudapi.com
+        - cam.tencentcloudapi.com
         ip: 169.254.0.95
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/incubator/tke-extend-network-controller/templates/networking.cloud.tencent.com_clbportpools.yaml
+++ b/incubator/tke-extend-network-controller/templates/networking.cloud.tencent.com_clbportpools.yaml
@@ -232,6 +232,37 @@ spec:
                 - InOrder
                 - Random
                 type: string
+              listenerPrecreate:
+                description: |-
+                  监听器预创建，预先为 lb 创建一些固定的监听器，不销毁，用于加快扩缩容时 CLB 的绑定和解绑速度。
+
+
+                  注意：预创建监听器的端口池只支持 TCP 和 UDP 协议（不支持 TCP_SSL 和 QUIC）。
+                properties:
+                  enabled:
+                    description: 是否启用监听器预创建
+                    type: boolean
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                  tcp:
+                    description: TCP 监听器预创建数量
+                    type: integer
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                  udp:
+                    description: UDP 监听器预创建数量
+                    type: integer
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                required:
+                - enabled
+                type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               listenerQuota:
                 description: |-
                   监听器数量配额。仅用在单独调整了指定 CLB 实例监听器数量配额的场景（TOTAL_LISTENER_QUOTA），

--- a/incubator/tke-extend-network-controller/templates/role.yaml
+++ b/incubator/tke-extend-network-controller/templates/role.yaml
@@ -242,3 +242,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - node.tke.cloud.tencent.com
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
将应用市场 chart 从 `2.4.1` 同步到 `2.4.2`，与组件 [v2.4.2 Release](https://github.com/tkestack/tke-extend-network-controller/releases/tag/v2.4.2) 对齐。

## 变更内容

| 文件 | 变更 | 对应组件变更 |
| --- | --- | --- |
| `Chart.yaml` | version/appVersion `2.4.1` → `2.4.2` | 版本对齐 |
| `templates/deployment.yaml` | hostAliases 增加 `cam.tencentcloudapi.com` | 修复：将 CAM 的 API 域名加到 deployment 的 hostAliases 中，避免无公网环境启动 controller 失败 |
| `templates/networking.cloud.tencent.com_clbportpools.yaml` | CRD 补充 `listenerPrecreate` 字段 | 新特性：端口池支持预创监听器（v2.4.0 引入，应用市场 chart 此前未同步） |
| `templates/role.yaml` | 增加 `node.tke.cloud.tencent.com/machines` 的 get/list/watch 权限 | 修复：支持 CVM 加成的原生节点，通过 Machine CR 的 `status.nodeRef.name` 确认原生节点身份 |

## 说明

- 镜像仓库保持 `ccr.ccs.tencentyun.com/tke-market/tke-extend-network-controller` 不变，由流水线同步镜像到 ccr。
- template 内容已与组件源码仓库 `charts/tke-extend-network-controller`（v2.4.2）逐文件比对一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)