### PR TITLE
tke-extend-network-controller: bump to 2.4.3

### DIFF
--- a/incubator/tke-extend-network-controller/Chart.yaml
+++ b/incubator/tke-extend-network-controller/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.2
+version: 2.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2.4.2
+appVersion: 2.4.3
 kubeVersion: '>= 1.26.0-0'


### PR DESCRIPTION
## 变更内容

将 tke-extend-network-controller chart 版本从 2.4.2 升级到 2.4.3。

仅更新 Chart.yaml 中的 `version` 和 `appVersion`，templates 和 values.yaml 无变化（与组件仓库 v2.4.3 tag 对齐，chart diff 仅版本号）。

## v2.4.3 Release Notes

- 修复：IP 复用导致 OtherTargetBound 死锁。VPC-CNI 非固定 IP 场景下，Pod 创建后 IP 变更，旧 IP 被其它 Pod 复用时，controller 想把 CLB 后端从旧 IP 更新为新 IP，但发现旧 IP 已属于另一个 Pod，OtherTargetBound 保护逻辑直接放弃纠正，导致端口永久指向错误 Pod，流量不可达。修复方式：收敛冲突判定，只有当持有旧 IP 的对象通过自己的 CLBBinding 合法占用了同一监听器时才保护（真冲突），否则视为历史残留，允许安全清理并替换为当前 Pod 真实 IP。CLBPodBinding 和 CLBNodeBinding 均适用。
- 新增：端到端测试框架（`make e2e`），基于 Ginkgo 在真实 TKE 集群中验证 CLB 端口映射全流程，覆盖 15 个测试用例，包括多协议映射、端口段映射、LB 分配策略、黑名单、自动扩容等场景。