### PR TITLE
tke-extend-network-controller: bump to 2.5.0

### DIFF
--- a/incubator/tke-extend-network-controller/Chart.yaml
+++ b/incubator/tke-extend-network-controller/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.3
+version: 2.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2.4.3
+appVersion: 2.5.0
 kubeVersion: '>= 1.26.0-0'


### PR DESCRIPTION
Bump tke-extend-network-controller chart version to 2.5.0 (appVersion 2.5.0).

Release: https://github.com/tkestack/tke-extend-network-controller/releases/tag/v2.5.0