### PR TITLE
tke-extend-network-controller: bump to 2.5.1

### DIFF
--- a/incubator/tke-extend-network-controller/Chart.yaml
+++ b/incubator/tke-extend-network-controller/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2.5.0
+appVersion: 2.5.1
 kubeVersion: '>= 1.26.0-0'


### PR DESCRIPTION
更新 tke-extend-network-controller chart 版本到 2.5.1，对齐控制器 v2.5.1 发版。

## v2.5.1 变更

- 性能优化：大规模 CLB 端口映射收敛速度提升（缓存+单飞、去多余Wait、批量20→500、通道100→800）
- 修复：CLB desState 冲突（ResourceInOperating）退避重试
- 修复：大规模缩容删除监听器竞态导致 CPB 卡 Deleting
- 300 Pod × 16 监听器实测：637s → 254s（-60%）
