### PR TITLE
Add Agent Portal Helm Chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ repo/community/index.yaml
 .travis.yml
 .DS_Store
 .idea
+workflow/

--- a/incubator/agent-portal/Chart.yaml
+++ b/incubator/agent-portal/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: agent-portal
+description: Tencent Cloud Agent Portal - enterprise platform with agent management, intent routing, multi-agent orchestration, observability and model management for TKE.
+type: application
+version: 2.0.0
+appVersion: "2.0.0"
+icon: https://agent-portal-1256076159.cos.ap-guangzhou.myqcloud.com/Portal-Docs20260804161651580.png
+home: https://portal.helloadp.com/
+
+maintainers:
+  - name: ADP Team

--- a/incubator/agent-portal/README.md
+++ b/incubator/agent-portal/README.md
@@ -1,0 +1,276 @@
+# agent-portal
+
+`agent-portal` 是用于在 TKE 上部署 Agent Portal（智能体门户）的 Helm Chart。
+
+Agent Portal 是面向企业的智能体统一入口，提供智能体接入与管理、意图总控与路由、多智能体协同编排、运行观测以及模型管理等能力，可对接腾讯云智能体开发平台（ADP）及其他 OpenAI 兼容模型服务。
+
+## 架构说明
+
+Chart 将 Agent Portal 部署为单个 Deployment（前后端同镜像，后端以 `SERVE_WEB=true` 同时托管前端静态资源）：
+
+- **Web 前端**：React 单页应用，由后端在 `APP_BASE_PATH` 子路径下托管
+- **后端服务**：Node.js 服务，监听 4000 端口，提供 REST API、SSE 会话与管理台接口
+- **db-init initContainer**：容器启动前执行数据库迁移（migrate）与初始化数据写入
+- **配置注入**：所有运行时配置由 Kubernetes Secret 渲染为 `.env`，挂载到 `/app/apps/server/.env`，避免数据库密码、对象存储密钥等进入 ConfigMap
+
+## 前置依赖
+
+部署前需自行准备以下外部资源，Chart 本身不包含这些组件：
+
+| 依赖 | 必填 | 说明 |
+| ---- | ---- | ---- |
+| MySQL / TDSQL-MySQL | ✅ | MySQL 8.0+ 或 TDSQL-MySQL；字符集 `UTF8MB4`；`lower_case_table_names=1`；需提前创建库与授权用户。购买：[MySQL](https://console.cloud.tencent.com/cdb/instance) / [TDSQL](https://console.cloud.tencent.com/tdsqld/instance-tdmysql) |
+| 对象存储 COS | ✅ | 用于头像、附件等文件存储；也可对接自建 MinIO。购买：[COS](https://console.cloud.tencent.com/cos) |
+| CLB + 域名 | ✅ | 对外访问入口，需绑定自定义域名。购买：[CLB](https://console.cloud.tencent.com/clb/instance) |
+| SSL 证书 | 条件必填 | `scheme=https` 时需在集群中准备 TLS Secret。申请：[SSL](https://console.cloud.tencent.com/ssl) |
+| SMTP 服务 | 可选 | 用于邮箱验证与密码重置 |
+
+> **注意**：数据库、COS 建议与 TKE 集群部署在**同一地域**，以获得最佳网络性能。
+
+## 配置说明
+
+以下是主要可配置的参数及默认值。
+
+### 镜像配置
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| image.repository | Agent Portal 镜像仓库地址 | ccr.ccs.tencentyun.com/tke-market/agent-portal |
+| image.tag | 镜像 Tag，为空时使用 Chart 的 appVersion | tke-market-license-dev-67799082-20260805-143502-amd64 |
+| image.pullPolicy | 镜像拉取策略 | Always |
+| imagePullSecrets | 私有仓库拉取凭据 | [] |
+| replicaCount | Deployment 副本数 | 2 |
+
+> 当前镜像仅提供 `linux/amd64` 架构，请确保调度到 amd64 节点；集群中混有 ARM 节点时，建议通过 `nodeSelector` 显式约束：
+>
+> ```yaml
+> nodeSelector:
+>   kubernetes.io/arch: amd64
+> ```
+
+### 访问配置
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| clb | **必填**，对外访问域名（绑定到 CLB 的自定义域名） | xx-portal.example.com |
+| scheme | 平台访问协议，`http` 或 `https` | https |
+| APP_BASE_PATH | 应用部署子路径，需与 `ingress.path` 保持一致；留空表示部署在根路径 | /agent-portal |
+| service.type | Service 类型 | ClusterIP |
+| service.port | Service 与容器端口 | 4000 |
+
+### ADP 接入配置
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| adp.apiEndpoint | ADP 云 API 地址，支持 host 或完整 URL | ""（复用 `clb`） |
+| adp.chatEndpoint | ADP 对话 SSE 完整地址 | ""（自动拼 `<scheme>://<clb>/adp/v2/chat`） |
+| adp.host | Portal 展示和同步时使用的 ADP Host | ""（自动拼 `<scheme>://<clb>`） |
+
+Portal 与 ADP 共用同一个 CLB/域名时无需配置本段；使用独立 ADP 地址时应显式填写。
+
+### Ingress 配置
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| ingress.enabled | 是否创建 Ingress | true |
+| ingress.className | IngressClass 名称，TKE 使用 `qcloud` | qcloud |
+| ingress.host | Ingress 域名，为空时取 `clb` | "" |
+| ingress.path | 路由路径，需与 `APP_BASE_PATH` 一致 | /agent-portal |
+| ingress.pathType | 路径匹配类型 | ImplementationSpecific |
+| ingress.tls | 是否启用 TLS，仅 `scheme=https` 时生效 | true |
+| ingress.tlsSecretName | TLS Secret 名称，为空时取 `<host>-secret` | "" |
+| ingress.annotations | Ingress 注解，默认放宽读写超时以适配 SSE 长连接 | 见 `values.yaml` |
+
+**TKE Ingress 使用注意事项**：
+- 如果集群网络模式未采用负载均衡直连 Pod 模式，后端 Service 的访问类型不能为 `ClusterIP`，需改为 `NodePort` 或 `LoadBalancer`
+- 负载均衡直连 Pod 模式详见：[TKE 文档](https://cloud.tencent.com/document/product/457/41897)
+
+### 数据库配置
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| db.host | **必填**，数据库主机地址 | 192.168.0.1 |
+| db.port | 数据库端口 | 3306 |
+| db.user | **必填**，数据库用户名 | \<YOUR_DB_USER\> |
+| db.password | **必填**，数据库密码 | \<YOUR_DB_PASSWORD\> |
+| db.name | 数据库名 | agent_portal |
+| db.type | 数据库兼容模式，`mysql` 或 `tdsql` | mysql |
+| db.connectionLimit | MySQL 连接池上限，多副本部署时建议保持默认 | 50 |
+
+> 容器启动时会自动执行迁移：空库执行初始化（建表 + 种子数据），已初始化的库仅执行 migrate。
+
+### 文件存储配置
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| storage.type | 存储类型，`s3`（含 COS / MinIO）或 `local` | s3 |
+| storage.bucket | **必填**，Bucket 名称，COS 需带 APPID 后缀 | \<YOUR_COS_BUCKET\> |
+| storage.region | **必填**，Bucket 所在地域 | \<YOUR_COS_REGION\> |
+| storage.endpoint | 访问 Endpoint，为空时按 region 自动拼 `https://cos.<region>.myqcloud.com` | "" |
+| storage.accessKey | **必填**，Access Key（COS 对应 SecretId） | \<YOUR_SECRET_ID\> |
+| storage.secretKey | **必填**，Secret Key | \<YOUR_SECRET_KEY\> |
+| storage.forcePathStyle | 路径风格寻址；COS 用 `false`，自建 MinIO 用 `true` | "false" |
+
+### 密钥配置
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| PORTAL_CREDENTIALS_KEY | **必填**，凭据加密与 token 签名密钥，要求 ≥ 32 字符 | \<YOUR_PORTAL_CREDENTIALS_KEY\> |
+| BETTER_AUTH_SECRET | **必填**，Session 加密密钥 | \<YOUR_BETTER_AUTH_SECRET\> |
+| AUTH_CUSTOMER_SECRET_KEY | Customer 免密登录签名密钥；未启用时可留空 | "" |
+
+**生成方式**：
+
+```bash
+openssl rand -base64 32
+```
+
+> ⚠️ **升级注意**：`PORTAL_CREDENTIALS_KEY` 用于加密已存储的 IM / Connector 凭据。已有存量数据的环境升级时必须沿用原值，重新生成会导致历史凭据无法解密。
+
+### 单点登录（SSO）配置
+
+支持通过标准 OAuth2 协议对接企业已有的身份认证系统，可选；不配置时使用账号密码登录。
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| AUTH_GENERIC_OAUTH_CLIENT_ID | OAuth2 Client ID | "" |
+| AUTH_GENERIC_OAUTH_CLIENT_SECRET | OAuth2 Client Secret | "" |
+| AUTH_GENERIC_OAUTH_AUTHORIZATION_URL | 授权端点地址 | "" |
+| AUTH_GENERIC_OAUTH_TOKEN_URL | Token 端点地址 | "" |
+| AUTH_GENERIC_OAUTH_USER_INFO_URL | 用户信息端点地址 | "" |
+| AUTH_GENERIC_OAUTH_SCOPES | 请求 Scope，多个值用空格分隔 | "read all" |
+
+Client ID、Client Secret 与三个端点需成组配置。用户信息字段映射、Token 认证方式等完整参数见 `values.yaml` 中的 `AUTH_GENERIC_OAUTH_*` 段。
+
+### 邮件配置
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| SMTP_HOST | SMTP 服务器地址 | "" |
+| SMTP_PORT | SMTP 端口 | "587" |
+| SMTP_USER | SMTP 用户名 | "" |
+| SMTP_PASS | SMTP 密码 | "" |
+| SMTP_FROM | 发件人地址 | "" |
+
+### 功能与登录开关
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| LOGIN_CAPTCHA_ENABLED | 是否启用登录图形验证码 | "true" |
+| LOGIN_CAPTCHA_PROVIDER | 验证码提供方：`cap`、`slider` 或 `character` | "cap" |
+| LOGIN_CAPTCHA_CHECK_IP | 验证码 IP 一致性校验；CGNAT / 多层代理环境建议关闭 | "false" |
+| FEATURE_ORCHESTRATION | 多智能体协同编排总开关 | "true" |
+| FULFILLMENT_AGENT_TIMEOUT_MS | 智能体履约超时（毫秒） | "30000" |
+| FULFILLMENT_MODEL_TIMEOUT_MS | 模型履约超时（毫秒） | "30000" |
+| FULFILLMENT_API_TIMEOUT_MS | API 履约超时（毫秒） | "15000" |
+| LOG_LEVEL | 日志级别，`trace` / `debug` / `info` / `warn` / `error` / `fatal` | info |
+| LOG_PRETTY | 日志美化输出，生产环境建议保持 `false` | "false" |
+
+管理台与用户端的各模块默认全部开启，无需额外配置。如需按需裁剪模块入口，请联系技术支持。
+
+### 资源与调度配置
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| resources.limits.cpu | CPU 上限 | "2" |
+| resources.limits.memory | 内存上限 | 4Gi |
+| resources.requests.cpu | CPU 请求 | "1" |
+| resources.requests.memory | 内存请求 | 2Gi |
+| nodeSelector | 节点选择器 | {} |
+| tolerations | 污点容忍 | [] |
+| affinity | 亲和性配置 | {} |
+| podAnnotations | Pod 注解 | {} |
+| podLabels | Pod 标签 | {} |
+
+## 示例
+
+### 最小配置部署
+
+创建 `my-values.yaml`：
+
+```yaml
+clb: "portal.example.com"
+scheme: https
+
+db:
+  host: "10.0.0.10"
+  port: 3306
+  user: "portal"
+  password: "<YOUR_DB_PASSWORD>"
+  type: mysql
+
+storage:
+  bucket: "portal-1250000000"
+  region: "ap-guangzhou"
+  accessKey: "<YOUR_COS_SECRET_ID>"
+  secretKey: "<YOUR_COS_SECRET_KEY>"
+
+PORTAL_CREDENTIALS_KEY: "<openssl rand -base64 32>"
+BETTER_AUTH_SECRET: "<openssl rand -base64 32>"
+```
+
+部署：
+
+```bash
+helm install agent-portal . -f my-values.yaml -n agent-portal --create-namespace
+```
+
+部署完成后访问 `https://portal.example.com/agent-portal`。
+
+### 部署到根路径
+
+```yaml
+APP_BASE_PATH: ""
+ingress:
+  path: /
+  pathType: Prefix
+```
+
+### 对接自建 MinIO
+
+```yaml
+storage:
+  bucket: "portal"
+  region: "us-east-1"
+  endpoint: "http://minio.default.svc.cluster.local:9000"
+  accessKey: "<YOUR_MINIO_ACCESS_KEY>"
+  secretKey: "<YOUR_MINIO_SECRET_KEY>"
+  forcePathStyle: "true"
+```
+
+### 查看状态与日志
+
+```bash
+kubectl -n agent-portal get deploy,po,svc,ingress -l app.kubernetes.io/name=agent-portal
+kubectl -n agent-portal logs -f deploy/agent-portal
+```
+
+## 常见 FAQ
+
+**1. Pod 一直处于 `Init:0/1`，`db-init` 容器反复失败**
+
+数据库连接不通或权限不足。检查 `db.host` / `db.port` 是否可从集群内访问、`db.user` 是否对 `db.name` 有建表权限，并确认数据库安全组已放通 TKE 集群网段：
+
+```bash
+kubectl -n agent-portal logs deploy/agent-portal -c db-init
+```
+
+**2. 启动报错提示数据库配置缺失**
+
+生产环境下 `db.host`、`db.user`、`db.password`、`db.name` 任一缺失都会在启动时抛错，以避免回退到 `localhost` / 空密码。若数据库确实使用空密码，请显式配置 `db.password: ""`。
+
+**3. 页面能打开但静态资源 404**
+
+`APP_BASE_PATH` 与 `ingress.path` 不一致。两者必须相同（例如都为 `/agent-portal`），否则前端资源路径与网关路由无法匹配。
+
+**4. 会话回复中断或长请求被截断**
+
+SSE 长连接被网关超时切断。确认 Ingress 保留了默认的读写超时注解（`proxy-read-timeout` / `proxy-send-timeout` 为 1800），如使用其他网关请配置等效的超时参数。
+
+**5. 升级后历史 IM / Connector 凭据无法解密**
+
+`PORTAL_CREDENTIALS_KEY` 被重新生成。请将原环境的 key 原样填回，该值用于存量凭据的 AES-256-GCM 解密。
+
+**6. 登录验证码总是校验失败**
+
+出口 IP 在两次请求间发生变化（CGNAT、多层负载均衡等场景）。将 `LOGIN_CAPTCHA_CHECK_IP` 设为 `"false"`。

--- a/incubator/agent-portal/README.md
+++ b/incubator/agent-portal/README.md
@@ -21,8 +21,8 @@ Chart 将 Agent Portal 部署为单个 Deployment（前后端同镜像，后端�
 | ---- | ---- | ---- |
 | MySQL / TDSQL-MySQL | ✅ | MySQL 8.0+ 或 TDSQL-MySQL；字符集 `UTF8MB4`；`lower_case_table_names=1`；需提前创建库与授权用户。购买：[MySQL](https://console.cloud.tencent.com/cdb/instance) / [TDSQL](https://console.cloud.tencent.com/tdsqld/instance-tdmysql) |
 | 对象存储 COS | ✅ | 用于头像、附件等文件存储；也可对接自建 MinIO。购买：[COS](https://console.cloud.tencent.com/cos) |
-| CLB + 域名 | ✅ | 对外访问入口，需绑定自定义域名。购买：[CLB](https://console.cloud.tencent.com/clb/instance) |
-| SSL 证书 | 条件必填 | `scheme=https` 时需在集群中准备 TLS Secret。申请：[SSL](https://console.cloud.tencent.com/ssl) |
+| CLB + 域名 | ✅ | 对外访问入口，需绑定自定义域名；填写 `clb` / `clbId`。购买：[CLB](https://console.cloud.tencent.com/clb/instance) |
+| SSL 证书 | 条件必填 | `clbScheme=https` 时填写 `clbCertId`，Chart 自动创建 TKE 用的证书 Secret。申请：[SSL](https://console.cloud.tencent.com/ssl) |
 | SMTP 服务 | 可选 | 用于邮箱验证与密码重置 |
 
 > **注意**：数据库、COS 建议与 TKE 集群部署在**同一地域**，以获得最佳网络性能。
@@ -53,7 +53,10 @@ Chart 将 Agent Portal 部署为单个 Deployment（前后端同镜像，后端�
 | Key | Description | Default |
 |-----|-------------|---------|
 | clb | **必填**，对外访问域名（绑定到 CLB 的自定义域名） | xx-portal.example.com |
-| scheme | 平台访问协议，`http` 或 `https` | https |
+| clbId | **必填**，已有 CLB 实例 ID，写入 `kubernetes.io/ingress.existLbId` | lb-example |
+| scheme | 平台访问协议，`http` 或 `https`（用于应用侧 Origin / Public URL） | https |
+| clbScheme | CLB 监听协议，`http` 或 `https`；可与 `scheme` 不同以支持 SSL Offload | https |
+| clbCertId | **`clbScheme=https` 时必填**，腾讯云 SSL 证书 ID；Chart 生成 Secret `<release>-agent-portal-clb-cert` | \<YOUR_CLB_CERT_ID\> |
 | APP_BASE_PATH | 应用部署子路径，需与 `ingress.path` 保持一致；留空表示部署在根路径 | /agent-portal |
 | service.type | Service 类型 | ClusterIP |
 | service.port | Service 与容器端口 | 4000 |
@@ -77,11 +80,13 @@ Portal 与 ADP 共用同一个 CLB/域名时无需配置本段；使用独立 AD
 | ingress.host | Ingress 域名，为空时取 `clb` | "" |
 | ingress.path | 路由路径，需与 `APP_BASE_PATH` 一致 | /agent-portal |
 | ingress.pathType | 路径匹配类型 | ImplementationSpecific |
-| ingress.tls | 是否启用 TLS，仅 `scheme=https` 时生效 | true |
-| ingress.tlsSecretName | TLS Secret 名称，为空时取 `<host>-secret` | "" |
-| ingress.annotations | Ingress 注解，默认放宽读写超时以适配 SSE 长连接 | 见 `values.yaml` |
+| ingress.tls | 是否启用 TLS；实际挂载还需 `clbScheme=https` | true |
+| ingress.tlsSecretName | TLS Secret 名称，为空时由 `clbCertId` 自动生成；填写后复用现成 Secret 且不再创建 | "" |
+| ingress.annotations | 额外 Ingress 注解；`existLbId` / `direct-access` 由模板按 `clbId` 自动注入 | {} |
 
 **TKE Ingress 使用注意事项**：
+- Chart 对齐 ADP：用 `clbId` 绑定已有 CLB，用 `clbCertId` 自动创建含 `qcloud_cert_id` 的 Secret（名称带 release 前缀，可与 ADP 同命名空间共存）
+- `nginx.ingress.kubernetes.io/*` 系列注解对 `qcloud` IngressClass 不生效，如需配置超时请在 CLB 监听器上调整
 - 如果集群网络模式未采用负载均衡直连 Pod 模式，后端 Service 的访问类型不能为 `ClusterIP`，需改为 `NodePort` 或 `LoadBalancer`
 - 负载均衡直连 Pod 模式详见：[TKE 文档](https://cloud.tencent.com/document/product/457/41897)
 
@@ -190,7 +195,10 @@ Client ID、Client Secret 与三个端点需成组配置。用户信息字段映
 
 ```yaml
 clb: "portal.example.com"
+clbId: lb-xxxxxxxx
 scheme: https
+clbScheme: https
+clbCertId: "<YOUR_CLB_CERT_ID>"
 
 db:
   host: "10.0.0.10"
@@ -265,7 +273,9 @@ kubectl -n agent-portal logs deploy/agent-portal -c db-init
 
 **4. 会话回复中断或长请求被截断**
 
-SSE 长连接被网关超时切断。确认 Ingress 保留了默认的读写超时注解（`proxy-read-timeout` / `proxy-send-timeout` 为 1800），如使用其他网关请配置等效的超时参数。
+SSE 长连接被链路上的超时切断。使用 TKE 默认的 `qcloud` IngressClass 时，流量由 CLB 承载，需要在 CLB 监听器上放宽会话保持与空闲超时。若前端还串接了自建网关（Nginx、APISIX 等），需同步放宽其读写超时。
+
+注意 `nginx.ingress.kubernetes.io/*` 系列注解仅对 Nginx Ingress Controller 生效，配置在 `qcloud` IngressClass 上不起作用。
 
 **5. 升级后历史 IM / Connector 凭据无法解密**
 

--- a/incubator/agent-portal/README.md
+++ b/incubator/agent-portal/README.md
@@ -1,4 +1,4 @@
-# agent-portal
+# Agent Portal
 
 `agent-portal` 是用于在 TKE 上部署 Agent Portal（智能体门户）的 Helm Chart。
 

--- a/incubator/agent-portal/templates/_helpers.tpl
+++ b/incubator/agent-portal/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agent-portal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "agent-portal.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "agent-portal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "agent-portal.labels" -}}
+helm.sh/chart: {{ include "agent-portal.chart" . }}
+{{ include "agent-portal.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "agent-portal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agent-portal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app: {{ include "agent-portal.name" . }}
+{{- end }}
+
+{{/*
+Runtime configuration Secret name
+*/}}
+{{- define "agent-portal.secretName" -}}
+{{- printf "%s-env" (include "agent-portal.fullname" .) }}
+{{- end }}
+
+{{/*
+Image reference
+*/}}
+{{- define "agent-portal.image" -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- end }}

--- a/incubator/agent-portal/templates/clb-cert-secret.yaml
+++ b/incubator/agent-portal/templates/clb-cert-secret.yaml
@@ -1,0 +1,13 @@
+{{- $clbScheme := default .Values.scheme .Values.clbScheme -}}
+{{- if and .Values.ingress.enabled (eq $clbScheme "https") (not .Values.ingress.tlsSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agent-portal.fullname" . }}-clb-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-portal.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  qcloud_cert_id: {{ .Values.clbCertId | quote }}
+{{- end }}

--- a/incubator/agent-portal/templates/configmap.yaml
+++ b/incubator/agent-portal/templates/configmap.yaml
@@ -1,0 +1,533 @@
+{{- $publicHost := .Values.ingress.host | default .Values.clb -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agent-portal.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-portal.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  .env: |
+    # ===== 基础地址（前端 + 后端） =====
+    # 可选：应用部署子路径，例如 /user1；留空表示部署在根路径 /
+    # 该值同时用于静态资源挂载、API 前缀兼容，以及认证 cookie 隔离
+    APP_BASE_PATH={{ .Values.APP_BASE_PATH }}
+    # Portal 对外可达服务地址；部署到子路径时可包含 APP_BASE_PATH
+    # 启用 OpenCode sandbox 时不能使用 localhost / 127.0.0.1 / ::1，因为这些地址在 sandbox 内不可访问
+    PORTAL_PUBLIC_URL={{ .Values.scheme }}://{{ $publicHost }}{{ .Values.APP_BASE_PATH }}
+    # CORS 允许的来源（多个用英文逗号分隔）
+    CLIENT_ORIGIN={{ .Values.scheme }}://{{ $publicHost }}
+    # 触发器 webhook 对外地址（公网部署时需要可访问）
+    # WEBHOOK_BASE_URL=
+    # 沙箱内 LLM 域名解析到可达 IP（逗号分隔 hostname:ip）；OpenSandbox 默认 DNS 对部分 LLM 域名不可达
+    # PORTAL_EXTRA_HOSTS=api.deepseek.com:183.131.191.171
+    # 特殊网络拓扑下可覆盖 OpenCode sandbox 访问 Portal 网关类服务的地址；默认从 PORTAL_PUBLIC_URL 派生
+    # 该地址会同时用于 Model Gateway、OpenCode MCP router、Skills MCP gateway 等 sandbox -> Portal 调用
+    # MODEL_GATEWAY_BASE_URL=
+    #
+    # 签发给外网/公有云智能体（ADP SaaS、Dify 云等）的 OpenAI 兼容 Base URL；Portal 在内网、DMZ 反代暴露网关时必填
+    # 示例：https://api.example.com/api/model-gateway/openai/v1
+    # MODEL_GATEWAY_EXTERNAL_BASE_URL=
+    # 旧部署兼容变量不建议新部署继续配置
+    #
+    # ─── 出站请求 SSRF 防护配置（对所有对外 HTTP 请求生效）─────────────────────
+    # 统一策略见 apps/server/src/utils/ssrfPolicy.ts，覆盖 safeFetch（Dify/画布/
+    # 意图履约/COS/会话标题等）与模型管理（连接测试 / 模型列表拉取）。
+    #
+    # 推荐：信创/内网用「白名单」精确放行，而不是整体关闭防护。
+    #
+    # SSRF_ALLOWED_DOMAINS：追加可信域名（含子域），逗号分隔或 JSON 数组。
+    #   命中后即使解析到内网 IP 也放行。例：
+    # SSRF_ALLOWED_DOMAINS=internal-llm.corp.local,gateway.corp.local
+    #
+    # SSRF_ALLOWED_IPS：追加可信 IP / CIDR（支持 IPv4 CIDR），逗号分隔或 JSON 数组。例：
+    # SSRF_ALLOWED_IPS=10.0.0.0/8,172.16.0.0/12,192.168.1.10
+    #
+    # SSRF_PROTECTION_DISABLED=true：全局关闭 SSRF 防护（最宽松）。
+    #   仅在网络完全可信的隔离环境下开启；公网/混合云部署严禁使用。
+    #
+    # MODEL_ALLOW_PRIVATE_NETWORK=true：仅对模型管理放开内网 IP 访问（兼容保留，
+    #   一般用 SSRF_ALLOWED_IPS / SSRF_ALLOWED_DOMAINS 即可）。
+    # ────────────────────────────────────────────────────────────────────────────
+
+    # ===== 服务端 =====
+    SERVER_PORT=4000
+    APP_NAME="agent-portal"
+    # ===== 腾讯云 ADP（可选，默认公有云；私有化/专有云请按实际地址覆盖） =====
+    # ADP 云 API 域名，支持填写 host 或完整 URL；显式写 http:// 或 https:// 会按该协议请求
+    ADP_API_ENDPOINT={{ .Values.adp.apiEndpoint | default .Values.clb }}
+    # ADP 对话 SSE 地址，支持填写 host 或完整 URL；只填 host 时默认补 /adp/v2/chat
+    ADP_CHAT_ENDPOINT={{ .Values.adp.chatEndpoint | default (printf "%s://%s/adp/v2/chat" .Values.scheme .Values.clb) }}
+    # 门户展示/同步时写入的 ADP Host，支持填写 host 或完整 URL
+    ADP_HOST={{ .Values.adp.host | default (printf "%s://%s" .Values.scheme .Values.clb) }}
+    # 日志级别：trace | debug | info | warn | error | fatal
+    LOG_LEVEL={{ .Values.LOG_LEVEL }}
+    # 是否隐藏辅助工具调用卡片（默认 true）。设为 false 时不隐藏任何工具调用记录
+    # CHAT_HIDE_AUXILIARY_TOOL_CALLS=true
+    # 日志美化（仅开发环境生效，默认 true，可设 false 关闭）
+    LOG_PRETTY={{ .Values.LOG_PRETTY }}
+    # Trace 日志开关（默认 true）
+    # LOG_TRACE_ENABLED=true
+    # Trace 日志级别：debug | info | warn | error（默认 info）
+    # LOG_TRACE_LEVEL=info
+    # 是否禁用日志截断（默认 true，开启后记录完整 prompt/response）
+    # LOG_NO_TRUNCATE=true
+    # 当 LOG_NO_TRUNCATE=false 时生效
+    # LOG_MAX_TEXT_LENGTH=500
+    NODE_ENV=production
+    SERVE_WEB=true
+    # VITE_DEV_SERVER_URL=http://localhost:5173
+
+    # ===== 文件存储（可选，默认本地文件系统） =====
+    STORAGE_TYPE={{ .Values.storage.type }}
+    S3_BUCKET={{ .Values.storage.bucket }}
+    S3_REGION={{ .Values.storage.region }}
+    S3_ENDPOINT={{ .Values.storage.endpoint | default (printf "https://cos.%s.myqcloud.com" .Values.storage.region) }}
+    S3_ACCESS_KEY_ID={{ .Values.storage.accessKey }}
+    S3_SECRET_ACCESS_KEY={{ .Values.storage.secretKey }}
+    # COS 默认 false；自建 MinIO 时在 values 中设为 true
+    S3_FORCE_PATH_STYLE={{ .Values.storage.forcePathStyle | default "false" }}
+    # LOCAL_UPLOAD_DIR=./uploads/avatars
+
+    # ===== OpenClaw Docker 一键部署（可选） =====
+    # Portal 下发的一键部署脚本会锁定 remote-claw 仓库版本与镜像标签
+    # OPENCLAW_REMOTE_CLAW_REPO=https://github.com/TencentCloudADP-DevRel/remote-claw.git
+    # OPENCLAW_REMOTE_CLAW_REF=main
+    # OPENCLAW_REMOTE_CLAW_INSTALL_SCRIPT=install.sh
+    # OPENCLAW_DOCKER_IMAGE=tencentcloudadpdevrel/openclaw-desktop:latest
+
+    # OpenClaw 沙箱托管部署默认走 service_runtime 沙箱，lease=null（不自动过期），
+    # 由 Portal 通过 destroyServiceWorkspace 显式销毁。这是为长跑安装+健康检查
+    # 流程留出空间；早期 300s 默认 lease 会在部署中途到期，导致沙箱被回收、
+    # 健康检查全程报 "Service workspace not found"。
+
+    # ===== OpenSandbox（可选，沙箱管理 / Code Builder 使用） =====
+    # 连接信息只通过服务端环境变量配置；管理台只展示并测试当前唯一连接
+    # OPENSANDBOX_SERVER_URL=http://opensandbox-server.default.svc.cluster.local:8080
+    # OPENSANDBOX_API_KEY=
+    # OPENSANDBOX_CONNECTION_NAME=Sandbox
+    # OPENSANDBOX_USE_SERVER_PROXY=true
+    # 以下运行参数作为初始值 / fallback；管理台保存后以管理台配置为准
+    # OPENSANDBOX_CODE_INTERPRETER_IMAGE=sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.1
+    # OpenCode 超级智能体 runtime 使用的专用镜像，需预装 opencode CLI。
+    # OPENSANDBOX_OPENCODE_IMAGE=docker/sandbox-templates:opencode
+    # OPENSANDBOX_DEFAULT_CPU=1
+    # OPENSANDBOX_DEFAULT_MEMORY=2Gi
+    # OPENSANDBOX_DEFAULT_TIMEOUT_SECONDS=300
+    # OPENSANDBOX_READY_TIMEOUT_SECONDS=60
+    # OPENSANDBOX_CREATE_MAX_ATTEMPTS=2
+    # OPENSANDBOX_DEFAULT_PREVIEW_PORT=5173
+    # 以下挂载与网络参数由服务端环境变量统一管理；PVC 默认只用一个，通过 subPath 区分 sessions / agents / users
+    # OPENSANDBOX_PVC_NAME=sandbox-data
+    # OpenSandbox PVC 上 Portal 工作区/会话文件卷的 subPath 模板（默认见 settingsService）：
+    # OPENSANDBOX_WORKSPACE_FILES_SUBPATH_TEMPLATE=workspaces/<spaceId>/<userId>/<workspaceId>
+    # OPENSANDBOX_AGENT_CODE_SUBPATH_TEMPLATE=agents/<spaceId>/<agentId>
+    # OPENSANDBOX_WORKSPACE_MOUNT_PATH=/workspace
+    # OPENSANDBOX_AGENT_CODE_MOUNT_PATH=/agent
+    # OPENSANDBOX_HOME_SUBPATH_TEMPLATE=users/<spaceId>/<userId>
+    # OPENSANDBOX_HOME_MOUNT_PATH=/portal-home
+    # OPENSANDBOX_NETWORK_POLICY_MODE=allow_all
+    # OPENSANDBOX_ALLOWED_EGRESS_TARGETS=[]
+    # 沙箱 PVC 文件存储（STORAGE_TYPE=sandbox 时生效）：Portal Pod 不挂载 PVC，通过专用长期沙箱读写 objects/ 子路径
+    # SANDBOX_STORAGE_IMAGE=sandbox-registry.cn-zhangjiakou.cr.aliyuncs.com/opensandbox/code-interpreter:v1.0.1
+    # SANDBOX_STORAGE_TIMEOUT_SECONDS=86400
+    # SANDBOX_STORAGE_CPU=0.5
+    # SANDBOX_STORAGE_MEMORY=512Mi
+    # SANDBOX_STORAGE_SUBPATH=objects
+    # SANDBOX_STORAGE_MOUNT_PATH=/storage
+
+    # ===== OpenTelemetry（可选） =====
+    # OTEL_ENABLED=true
+    # OTEL_SERVICE_NAME=agent-portal-server
+    # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+    # OTEL_LOG_LEVEL=info
+
+    # ===== License（是否启用由打包时 BUILD_ENABLE_LICENSE 决定） =====
+    # 本地开发和普通构建默认不启用 License。
+    # 如需启用，请在构建阶段传入 BUILD_ENABLE_LICENSE=true，例如：
+    #   make pack BUILD_ENABLE_LICENSE=true
+    #   make push BUILD_ENABLE_LICENSE=true
+    # 模式选择：
+    # - adp     = 专有云 / ADP 激活码模式
+    # - private = 私有化 / 授权服务模式
+    # 优先读取 LICENSE_MODE；LICENSE_STRATEGY 作为兼容别名保留
+    LICENSE_MODE={{ .Values.LICENSE_MODE }}
+    # LICENSE_STRATEGY=adp
+    # ===== 专有云 / ADP 激活码模式 =====
+    # 复用 platform-manager 的 RSA 公钥，支持 \n 形式的单行 PEM
+    # LICENSE_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----
+    LICENSE_HOST_ADP={{ .Values.LICENSE_HOST_ADP | default (printf "%s://%s/cgi/apex/test/adp/platform/CheckLicense" .Values.scheme .Values.clb) }}
+    # ProductType 固定校验为 4，服务端不再读取 LICENSE_PRODUCT_TYPE
+    # 可选：手动指定实例 ID；不填时会在集群内自动读取 kube-system namespace UID
+    # LICENSE_INSTANCE_ID=
+    # 可选：后台自动续期任务间隔，最小 60000（默认 900000）
+    # LICENSE_RENEW_INTERVAL_MS=900000
+
+    # ===== 默认对话 LLM（未选择智能体时使用） =====
+    # LLM_SYSTEM_PROMPT=你是一个有帮助的智能助手。
+    # LLM_MAX_HISTORY=20
+
+    # ===== OpenAI 兼容默认模型（可选，供 DeepAgent Local `runtimeModelId=env` 等链路回退使用） =====
+    # OPENAI_API_KEY=your-openai-compatible-api-key
+    # OPENAI_BASE_URL=https://openrouter.ai/api/v1
+    # OPENAI_MODEL=gpt-4.1-mini
+
+    # ===== 数据库 =====
+    # 生产环境必填：以下 4 项任一缺失都会在启动时抛错，阻止退回到 localhost/root/空密码。
+    # DB_PORT 保留 3306 默认值（MySQL 标准端口约定）。
+    # 若数据库确实使用空密码（仅内网 + socket 鉴权），请显式写 `DB_PASSWORD=`，
+    # 不允许完全省略该变量。
+    DB_HOST={{ .Values.db.host }}
+    DB_PORT={{ .Values.db.port | quote }}
+    DB_USER={{ .Values.db.user | quote }}
+    DB_PASSWORD={{ .Values.db.password }}
+    DB_NAME={{ .Values.db.name }}
+    # MySQL 连接池上限；IM 长连接和调度器会长期占用 leader lock 连接。
+    DB_CONNECTION_LIMIT={{ .Values.db.connectionLimit }}
+    # 数据库兼容模式：mysql（默认）/ tdsql。TDSQL 部署设为 tdsql。
+    DB_COMPATIBILITY={{ .Values.db.type }}
+    # 可选：容器启动前自动准备数据库
+    # - 空库：执行 init（建库 + migrate + seed）
+    # - 已初始化库：仅执行 migrate
+    # 推荐在私有化环境首启或升级时临时打开，完成后再关闭
+    DB_INIT_ON_START=true
+    # 数据库连接时区（建议统一使用 UTC：+00:00 / Z）
+    DB_TIMEZONE=+00:00
+
+    # ===== Better Auth/Auth Customer Key 必须配置=====
+    # 必填：用于加密 session 的密钥（生成方法：openssl rand -base64 32）
+    BETTER_AUTH_SECRET={{ .Values.BETTER_AUTH_SECRET }}
+    # 可选：Customer 签名密钥（生成方法：openssl rand -base64 32）
+    AUTH_CUSTOMER_SECRET_KEY={{ .Values.AUTH_CUSTOMER_SECRET_KEY }}
+    # 可选：iOA登录，站点token
+    # AUTH_IOA_SITE_TOKEN=
+    #AUTH_IOA_EMAIL_DOMAIN=example.com
+    # 可选：iOA 官方登录入口根地址（通常只填 origin；若配置 APP_BASE_PATH，后端会自动拼上该子路径）
+    #AUTH_IOA_OFFICIAL_LOGIN_ORIGIN=https://agent-portal.testsite.woa.com
+
+    # ===== Portal 凭据密钥（所有环境必填） =====
+    # 统一用于 IM / Connector 凭据 AES-256-GCM 加密，以及 Connector Gateway / OpenCode 托管 MCP token HMAC 签名。
+    # 旧配置 CONNECTOR_CREDENTIALS_KEY / IM_CREDENTIALS_KEY / CONNECTOR_GATEWAY_SECRET 已废弃，请迁移到此项。
+    # 要求 >= 32 字符且非占位符。全新环境用 `openssl rand -base64 32` 生成。
+    # 已有存量加密凭据的环境：把原旧 key 的值原样填入，切勿重新生成，否则历史凭据无法解密。
+    PORTAL_CREDENTIALS_KEY={{ .Values.PORTAL_CREDENTIALS_KEY }}
+
+    # ===== 其他专用签名密钥（生产必填） =====
+    # 开发环境未配置时会为当前进程生成临时随机值；服务重启后历史 token 将失效，仅适合本地开发。
+    # SDK Proxy access token HMAC 签名密钥
+    # SDK_PROXY_SECRET=
+    # Connector Gateway token 有效期（毫秒，默认 12 小时）
+    # CONNECTOR_GATEWAY_TOKEN_TTL_MS=43200000
+    # ClawHub CLI /cli/auth confirm token HMAC 签名密钥
+    # CLAWHUB_CLI_AUTH_SECRET=
+    # 可选：钉钉 SSO 回调地址；建议显式配置为开放平台登记的完整回调 URL
+    AUTH_DINGTALK_CALLBACK_URL={{ .Values.AUTH_DINGTALK_CALLBACK_URL }}
+    # 可选：ADP OAuth2 IdP / 通用 OAuth2 SSO 配置见下方独立小节
+
+    # 可选：Customer 登录允许的时间戳偏差（秒），默认 60
+    # AUTH_CUSTOMER_TIMESTAMP_SKEW_SECONDS=60
+    # 可选：Customer nonce 防重放窗口（秒），默认 180
+    # AUTH_CUSTOMER_NONCE_TTL_SECONDS=180
+    # TOF 头像服务配置（可选，用于 iOA 登录用户头像）
+    TOF_AVATAR_BASE_URL=https://r.hrc.woa.com
+    TOF_AVATAR_SIZE=500
+
+    # ===== Connector 授权配置（可选） =====
+    # Google Drive / Gmail OAuth
+    # CONNECTOR_GOOGLE_CLIENT_ID=
+    # CONNECTOR_GOOGLE_CLIENT_SECRET=
+    # 可选：Google Drive / Gmail 专属 redirect URI（例如复用外部静态 callback 页）
+    # CONNECTOR_GOOGLE_REDIRECT_URL=
+    # 可选：Notion 专属 redirect URI
+    # CONNECTOR_NOTION_REDIRECT_URL=
+    # 可选：Lexiang Knowledge Base 专属 redirect URI
+    # CONNECTOR_LEXIANG_REDIRECT_URL=
+    # connector OAuth 回调基础地址默认从 PORTAL_PUBLIC_URL + /api 派生
+    # OpenSandbox 远程沙箱访问 Portal API 的地址（PORTAL_PUBLIC_URL 为 localhost 时必填，例如内网域名或 host.docker.internal:4000）
+    # SANDBOX_REACHABLE_PORTAL_URL=
+
+    # ===== 邮件服务配置（可选，用于邮箱验证和密码重置） =====
+    # 是否启用邮件发送；未启用时发送/测试都会被拒绝
+    # MAIL_ENABLED=false
+    # 邮件 provider：smtp | resend | sendgrid；未配置时默认 smtp
+    # MAIL_TYPE=smtp
+    # 默认发件人；未配置时回退 SMTP_FROM
+    # MAIL_DEFAULT_SEND_FROM=noreply@example.com
+    # MAIL_DEFAULT_SEND_FROM_NAME=Agent Portal
+    # MAIL_DEFAULT_REPLY_TO=
+    SMTP_HOST={{ .Values.SMTP_HOST }}
+    SMTP_PORT={{ .Values.SMTP_PORT }}
+    SMTP_USER={{ .Values.SMTP_USER }}
+    SMTP_PASS={{ .Values.SMTP_PASS }}
+    SMTP_FROM={{ .Values.SMTP_FROM }}
+    # SMTP_USE_TLS=false
+    # SMTP_OPPORTUNISTIC_TLS=false
+    # RESEND_API_KEY=
+    # SENDGRID_API_KEY=
+    # 兼容旧别名（仅存量环境迁移时使用，不建议新部署继续配置）
+    # SMTP_SERVER=smtp.example.com
+    # SMTP_USERNAME=your-smtp-user
+    # SMTP_PASSWORD=your-smtp-password
+
+    # ===== Intent Router 兼容兜底配置（可选） =====
+    # 意图路由模型优先在后台「模型管理 / 意图路由设置」中配置。
+    # 下列环境变量仅用于数据库尚无模型配置时的兼容兜底，新部署不建议依赖。
+    # INTENT_ROUTER_MODEL=deepseek/deepseek-chat
+    # INTENT_ROUTER_FALLBACK_MODEL=deepseek/deepseek-chat
+    # INTENT_ROUTER_EMBEDDING_MODEL=qwen/qwen3-embedding-4b
+    # INTENT_ROUTER_DEFAULT_BASE_URL=https://openrouter.ai/api/v1
+    # INTENT_ROUTER_DEFAULT_API_KEY=
+
+    # ===== Intent Router 缓存配置（可选） =====
+    # 缓存后端：memory | redis；未配置时默认 memory
+    # INTENT_ROUTER_CACHE_TYPE=memory
+    # INTENT_ROUTER_REDIS_HOST=localhost
+    # INTENT_ROUTER_REDIS_PORT=6379
+    # INTENT_ROUTER_REDIS_PASSWORD=
+
+    # ===== 履约执行超时配置（单位：毫秒） =====
+    # 智能体履约超时时间（默认 30000ms = 30秒）
+    FULFILLMENT_AGENT_TIMEOUT_MS={{ .Values.FULFILLMENT_AGENT_TIMEOUT_MS }}
+    # 模型履约超时时间（默认 30000ms = 30秒）
+    FULFILLMENT_MODEL_TIMEOUT_MS={{ .Values.FULFILLMENT_MODEL_TIMEOUT_MS }}
+    # API 履约超时时间（默认 15000ms = 15秒）
+    FULFILLMENT_API_TIMEOUT_MS={{ .Values.FULFILLMENT_API_TIMEOUT_MS }}
+
+    # ===== 钉钉 SSO（可选） =====
+    AUTH_DINGTALK_CLIENT_ID={{ .Values.AUTH_DINGTALK_CLIENT_ID }}
+    AUTH_DINGTALK_CLIENT_SECRET={{ .Values.AUTH_DINGTALK_CLIENT_SECRET }}
+    # 可选：钉钉 OAuth scope；默认 openid Contact.User.Read
+    AUTH_DINGTALK_SCOPE={{ .Values.AUTH_DINGTALK_SCOPE }}
+    # 可选：未返回企业邮箱时使用的合成邮箱域名；默认 sso.local
+    AUTH_DINGTALK_EMAIL_DOMAIN={{ .Values.AUTH_DINGTALK_EMAIL_DOMAIN }}
+
+    # ===== ADP OAuth2 IdP（可选） =====
+    AUTH_ADP_OAUTH_BASE_URL={{ .Values.AUTH_ADP_OAUTH_BASE_URL }}
+    AUTH_ADP_OAUTH_CLIENT_ID={{ .Values.AUTH_ADP_OAUTH_CLIENT_ID }}
+    AUTH_ADP_OAUTH_CLIENT_SECRET={{ .Values.AUTH_ADP_OAUTH_CLIENT_SECRET }}
+    AUTH_ADP_OAUTH_CALLBACK_URL={{ .Values.AUTH_ADP_OAUTH_CALLBACK_URL }}
+    AUTH_ADP_OAUTH_EMAIL_DOMAIN={{ .Values.AUTH_ADP_OAUTH_EMAIL_DOMAIN }}
+
+    # ===== 单通用 OAuth2 SSO（可选，provider id 固定为 generic） =====
+    AUTH_GENERIC_OAUTH_CLIENT_ID={{ .Values.AUTH_GENERIC_OAUTH_CLIENT_ID }}
+    AUTH_GENERIC_OAUTH_CLIENT_SECRET={{ .Values.AUTH_GENERIC_OAUTH_CLIENT_SECRET }}
+    AUTH_GENERIC_OAUTH_AUTHORIZATION_URL={{ .Values.AUTH_GENERIC_OAUTH_AUTHORIZATION_URL }}
+    AUTH_GENERIC_OAUTH_TOKEN_URL={{ .Values.AUTH_GENERIC_OAUTH_TOKEN_URL }}
+    AUTH_GENERIC_OAUTH_USER_INFO_URL={{ .Values.AUTH_GENERIC_OAUTH_USER_INFO_URL }}
+    AUTH_GENERIC_OAUTH_SCOPES={{ .Values.AUTH_GENERIC_OAUTH_SCOPES }}
+    AUTH_GENERIC_OAUTH_TOKEN_AUTH_METHOD={{ .Values.AUTH_GENERIC_OAUTH_TOKEN_AUTH_METHOD }}
+    AUTH_GENERIC_OAUTH_AUTHORIZATION_PARAMS={{ .Values.AUTH_GENERIC_OAUTH_AUTHORIZATION_PARAMS }}
+    AUTH_GENERIC_OAUTH_USER_INFO_AUTH_METHOD={{ .Values.AUTH_GENERIC_OAUTH_USER_INFO_AUTH_METHOD }}
+    AUTH_GENERIC_OAUTH_USER_INFO_TOKEN_PARAM={{ .Values.AUTH_GENERIC_OAUTH_USER_INFO_TOKEN_PARAM }}
+    AUTH_GENERIC_OAUTH_USER_ID_FIELD={{ .Values.AUTH_GENERIC_OAUTH_USER_ID_FIELD }}
+    AUTH_GENERIC_OAUTH_EMAIL_FIELD={{ .Values.AUTH_GENERIC_OAUTH_EMAIL_FIELD }}
+    AUTH_GENERIC_OAUTH_NAME_FIELD={{ .Values.AUTH_GENERIC_OAUTH_NAME_FIELD }}
+    AUTH_GENERIC_OAUTH_USERNAME_FIELD={{ .Values.AUTH_GENERIC_OAUTH_USERNAME_FIELD }}
+    AUTH_GENERIC_OAUTH_DEPARTMENT_FIELD={{ .Values.AUTH_GENERIC_OAUTH_DEPARTMENT_FIELD }}
+    AUTH_GENERIC_OAUTH_EMAIL_DOMAIN={{ .Values.AUTH_GENERIC_OAUTH_EMAIL_DOMAIN }}
+
+    # ===== 协同编排模块（Feature Flags） =====
+    # 总开关：启用多智能体编排、智能分流、编排记录等功能
+    FEATURE_ORCHESTRATION={{ .Values.FEATURE_ORCHESTRATION }}
+    # 规则型协同（默认 true，总开关开启时生效）
+    FEATURE_ORCHESTRATION_RULE=true
+    # 规划型协同 Phase 2（默认 false）
+    FEATURE_ORCHESTRATION_PLANNER=false
+
+    # 编排运行默认超时（未在单个 plannerConfig.maxDurationMs 覆盖时生效）
+    # ORCHESTRATION_RUN_DEFAULT_MAX_DURATION_MS=120000
+    # running 状态超过该阈值仍未结束时，会被后台回收任务标记为 timeout
+    # ORCHESTRATION_RUN_RECLAIM_GRACE_MS=900000
+    # stuck run 回收任务 cron（默认每 5 分钟）
+    # ORCHESTRATION_RUN_RECLAIM_CRON=*/5 * * * *
+
+    # ===== 实验性功能开关（默认未配置即关闭；只有 true 时开启） =====
+    # 说明：
+    # - 以下功能默认不交付，只有显式配置为 true 才会打开
+    # - 前后端都通过 /api/feature-flags 读取服务端解析结果
+    #
+    # 解决方案 /solutions
+    # FEATURE_EXPERIMENTAL_SOLUTIONS=true
+    # 用户端连接中心 /connectors
+    # FEATURE_EXPERIMENTAL_CONNECTOR_CENTER=true
+    # Canvas /canvas
+    # FEATURE_EXPERIMENTAL_CANVAS=true
+    # 新建 DeepAgent Local（仅控制新建入口与创建动作）
+    # FEATURE_EXPERIMENTAL_DEEPAGENT_LOCAL_CREATE=true
+    # 多智能体协同编排（控制意图达成方式中的多智能体相关功能）
+    FEATURE_EXPERIMENTAL_MULTI_AGENT_ORCHESTRATION=true
+
+    # ===== 管理台功能开关（稳定模块默认开；实验性模块默认关） =====
+    # 说明：
+    # - 一级模块关闭后，所属二级模块即使未配置或显式 true，也会一起关闭
+    # - 二级模块用于精细裁剪单个后台页面；关闭后直达时会显示“功能已关闭”
+    # - 稳定模块：未配置即开启；显式 false 时关闭
+    # - 实验性模块：未配置即关闭；只有 true 时开启
+    # - 以下名称与后台 canonical 路由一一对应
+    #
+    # 一级模块
+    # 总览 /dashboard/overview
+    # FEATURE_DASHBOARD_OVERVIEW=false
+    # 智能体中心 /dashboard/agent-management
+    # FEATURE_DASHBOARD_AGENT_MANAGEMENT=false
+    # 意图总控 /dashboard/intent-control
+    # FEATURE_DASHBOARD_INTENT_CONTROL=false
+    # 运行观测 /dashboard/observation
+    # FEATURE_DASHBOARD_OBSERVATION=false
+    # 资源中心 /dashboard/resource-center
+    # FEATURE_DASHBOARD_RESOURCE_CENTER=false
+    # 模型中心 /dashboard/model-evaluation
+    # FEATURE_DASHBOARD_MODEL_EVALUATION=false
+    # 系统设置 /dashboard/system-settings
+    # FEATURE_DASHBOARD_SYSTEM_SETTINGS=false
+    #
+    # 二级模块
+    # 智能体管理 /dashboard/agent-management/agent-center
+    # FEATURE_DASHBOARD_AGENT_CENTER=false
+    # 智能体平台管理 /dashboard/agent-management/platform-connection
+    # FEATURE_DASHBOARD_PLATFORM_CONNECTION=false
+    # 技能列表 /dashboard/resource-center/skill-list（实验性，默认关，须 true）
+    # FEATURE_DASHBOARD_SKILL_LIST=true
+    # MCP 服务 /dashboard/resource-center/mcp-servers（稳定模块，随资源中心开启；无单独 env）
+    # 触发器管理 /dashboard/agent-management/trigger-management
+    # FEATURE_DASHBOARD_TRIGGER_MANAGEMENT=false
+    # IM 渠道管理 /dashboard/agent-management/im-channels
+    # FEATURE_DASHBOARD_IM_CHANNELS=false
+    # 意图概览 /dashboard/intent-control/intent-overview
+    # FEATURE_DASHBOARD_INTENT_OVERVIEW=false
+    # 意图管理 /dashboard/intent-control/intent-library
+    # FEATURE_DASHBOARD_INTENT_LIBRARY=false
+    # 意图达成方式 /dashboard/intent-control/fulfillment-strategies
+    # FEATURE_DASHBOARD_FULFILLMENT_STRATEGIES=false
+    # 意图测试 /dashboard/intent-control/routing-test
+    # FEATURE_DASHBOARD_ROUTING_TEST=false
+    # 意图追溯 /dashboard/intent-control/runtime-trace
+    # FEATURE_DASHBOARD_RUNTIME_TRACE=false
+    #
+    # 整体观测 /dashboard/observation/observation-dashboard
+    # FEATURE_DASHBOARD_OBSERVATION_DASHBOARD=false
+    # 请求列表 /dashboard/observation/observation-list
+    # FEATURE_DASHBOARD_OBSERVATION_LIST=false
+    # 会话列表 /dashboard/observation/session-list
+    # FEATURE_DASHBOARD_SESSION_LIST=false
+    # 记忆层 /dashboard/resource-center/memory-layer
+    # FEATURE_DASHBOARD_MEMORY_LAYER=false
+    # 技能审计日志 /dashboard/resource-center/skill-list?tab=audit（实验性）
+    # FEATURE_DASHBOARD_SKILL_AUDIT_LOG=true
+    #
+    # 沙箱管理 /dashboard/resource-center/sandbox-management（实验性）
+    # FEATURE_DASHBOARD_SANDBOX_MANAGEMENT=true
+    # 文件存储 /dashboard/resource-center/file-storage（实验性）
+    # FEATURE_DASHBOARD_FILE_STORAGE=true
+    # 连接器 /dashboard/resource-center/connector-definitions + /dashboard/resource-center/connector-center
+    # FEATURE_DASHBOARD_CONNECTORS=false
+    #
+    # 模型管理 /dashboard/model-evaluation/model-management
+    # FEATURE_DASHBOARD_MODEL_MANAGEMENT=false
+    # 模型体验 /dashboard/model-evaluation/model-testing
+    # FEATURE_DASHBOARD_MODEL_TESTING=false
+    #
+    # 基础设置 /dashboard/system-settings/settings-basic
+    # FEATURE_DASHBOARD_SETTINGS_BASIC=false
+    # 通知设置 /dashboard/auth-notifications/notification-settings
+    # FEATURE_DASHBOARD_NOTIFICATION_SETTINGS=false
+    # 用户端展示设置 /dashboard/system-settings/portal-experience
+    # FEATURE_DASHBOARD_AGENT_DISPLAY=false
+    # 认证设置 /dashboard/system-settings/settings-auth
+    # FEATURE_DASHBOARD_SETTINGS_AUTH=false
+    # 许可证管理 /dashboard/system-settings/settings-license
+    # FEATURE_DASHBOARD_SETTINGS_LICENSE=false
+    # 空间管理 /dashboard/system-settings/settings-spaces
+    # FEATURE_DASHBOARD_SETTINGS_SPACES=false
+    # 角色授权 /dashboard/system-settings/settings-role-assignment
+    # FEATURE_DASHBOARD_SETTINGS_ROLE_ASSIGNMENT=false
+    # 用户权限 /dashboard/system-settings/settings-users
+    # FEATURE_DASHBOARD_SETTINGS_USERS=false
+
+    # ===== 用户端功能开关（稳定功能：未配置 = 开启；显式 false = 关闭） =====
+    # 说明：
+    #   - 作用于用户端导航入口（非管理端）
+    #   - 稳定功能默认开启，Lite 部署可按需关闭
+    #   - FEATURE_USER_HOME 关闭后，访问 / 自动跳转到第一个可达入口
+    #
+    # 首页（/ 根路径，关闭后所有用户均跳转）
+    # FEATURE_USER_HOME=false
+    # 首页新会话默认模式：workbench 或 intent
+    # USER_HOME_DEFAULT_MODE=intent
+    # 智能工作台 /workbench（用户侧入口总开关）
+    # FEATURE_USER_WORKBENCH=false
+    # 智能工作台 provider 部署配置：pi_inprocess（默认）、opencode 或 adp_workbench
+    # 默认只通过 .env 配置，不在后台页面在线切换
+    # WORKBENCH_PROVIDER=pi_inprocess
+    # 当 provider=pi_inprocess 时，使用 Pi 进程内智能体；可复用后台超级智能体配置页选择运行模型
+    # 当 provider=opencode 时，使用 OpenCode 沙箱超级智能体；需配置下方 OpenCode 运行时，且后台 opencode 智能体配置页与创建能力自动启用
+    # WORKBENCH_PROVIDER=opencode
+    # 内部调试开关：开启后后台可在线切换智能工作台 provider，且 DB 配置优先于 WORKBENCH_PROVIDER
+    # 关闭时 WORKBENCH_PROVIDER 是唯一事实来源，后台不会展示在线切换入口
+    # WORKBENCH_PROVIDER_DEBUG_SWITCH_ENABLED=false
+    # ADP 工作台地址；仅 WORKBENCH_PROVIDER=adp_workbench 时使用
+    # WORKBENCH_ADP_URL=
+    # 个人助理 /personal-assistant
+    # FEATURE_USER_PERSONAL_ASSISTANT=false
+    # 工作搭子 /team
+    # FEATURE_USER_TEAM=false
+
+    # ===== OpenCode 运行时（WORKBENCH_PROVIDER=opencode 时必填；画布网页模式亦可能共用） =====
+    # OpenCode 服务地址（通过 opencode serve 启动，默认 http://127.0.0.1:4096）
+    # OPENCODE_BASE_URL=http://127.0.0.1:4096
+    # OpenCode 单轮对话超时（毫秒），默认 500000
+    # OPENCODE_CHAT_TIMEOUT_MS=500000
+    # OpenCode 基础认证（可选）
+    # OPENCODE_SERVER_USERNAME=
+    # OPENCODE_SERVER_PASSWORD=
+    # OpenCode 默认模型（当未指定 modelConfigId 时使用）
+    # OPENCODE_MODEL=
+
+    # ===== 智能工作台调试（本地/测试可选） =====
+    # 打开后写入超级智能体 / 智能工作台 provider 的 prompt 调试快照到 .workspace/workbench-debug/
+    # WORKBENCH_DEBUG=on
+
+    # 是否启用登录图形验证码（默认 true；本地调试可设为 false）
+    LOGIN_CAPTCHA_ENABLED={{ .Values.LOGIN_CAPTCHA_ENABLED }}
+    # 验证码提供方：cap、slider 或 character
+    LOGIN_CAPTCHA_PROVIDER={{ .Values.LOGIN_CAPTCHA_PROVIDER }}
+    # 是否开启验证码 IP 一致性校验（默认 true）
+    # 在 CGNAT / 负载均衡 / 代理等场景下，用户两次请求的出口 IP 可能不同，设为 false 可关闭
+    LOGIN_CAPTCHA_CHECK_IP={{ .Values.LOGIN_CAPTCHA_CHECK_IP }}
+    # ===== 私有化 / 授权服务模式 =====
+    # 仅当 LICENSE_MODE=private 时生效；TKE 部署使用 adp 模式，以下取值固定
+    LICENSE_SERVER_URL=
+    LICENSE_SPU_CODE=spu_tencent_cloud_agent_development_platform_subscription_license
+    LICENSE_PRICING_CODE=standard_edition_private_cloud_subscription_license
+    LICENSE_RULE_KEY=adp_agent_count
+    LICENSE_AUTH_TYPE=NODE_RESTRICTED
+    LICENSE_LANGUAGE={{ .Values.LICENSE_LANGUAGE }}
+
+    # 许可证跳过令牌（可选，用于无许可证服务器的场景）
+    # 仅当 LICENSE_MODE=private 时生效
+    # 不配置 LICENSE_SERVER_URL 时，若也不配置此项，则所有写操作被拦截
+    # 此 token 由开发方使用 RSA 私钥签名生成，客户无法自行生成
+    # 需要时请联系开发方获取
+    # LICENSE_BYPASS_TOKEN=
+
+    # ===== Observability · 外部 DLP / 安全平台事件接收 =====
+    # 用于 POST /api/observability/security-event 的 Bearer token 鉴权
+    # 外部 DLP / 安全平台调用方需在请求头携带：
+    #   Authorization: Bearer <OBSERVABILITY_SECURITY_EVENT_TOKEN>
+    # 或：
+    #   X-Observability-Security-Event-Token: <OBSERVABILITY_SECURITY_EVENT_TOKEN>
+    # 未配置时该接口直接返回 503，避免默认放通
+    # OBSERVABILITY_SECURITY_EVENT_TOKEN=
+    #
+    # 外部入口加固（P1.9-a）—— 以下三个参数可选，未配置时使用默认值
+    # 分钟级限流：默认 60 次/分钟/token
+    # OBSERVABILITY_SECURITY_EVENT_RATE_LIMIT_PER_MIN=60
+    # 秒级突发限流：默认 10 次/秒/token
+    # OBSERVABILITY_SECURITY_EVENT_BURST_PER_SEC=10
+    # 单包体积上限：默认 256kb，支持 b/kb/mb 后缀
+    # OBSERVABILITY_SECURITY_EVENT_BODY_LIMIT=256kb
+    # IP 维度分钟级限流：默认 120 次/分钟/IP，独立于 token 维度，挡 token 轮换攻击
+    # OBSERVABILITY_SECURITY_EVENT_RATE_LIMIT_PER_IP_PER_MIN=120
+    # IP 维度秒级突发限流：默认 30 次/秒/IP
+    # OBSERVABILITY_SECURITY_EVENT_BURST_PER_IP_PER_SEC=30

--- a/incubator/agent-portal/templates/configmap.yaml
+++ b/incubator/agent-portal/templates/configmap.yaml
@@ -52,7 +52,8 @@ stringData:
     # ────────────────────────────────────────────────────────────────────────────
 
     # ===== 服务端 =====
-    SERVER_PORT=4000
+    # 与 service.port 保持一致，同时作为 containerPort 与探针目标端口
+    SERVER_PORT={{ .Values.service.port }}
     APP_NAME="agent-portal"
     # ===== 腾讯云 ADP（可选，默认公有云；私有化/专有云请按实际地址覆盖） =====
     # ADP 云 API 域名，支持填写 host 或完整 URL；显式写 http:// 或 https:// 会按该协议请求

--- a/incubator/agent-portal/templates/deployment.yaml
+++ b/incubator/agent-portal/templates/deployment.yaml
@@ -1,0 +1,115 @@
+{{- $healthPath := printf "%s/api/health" (trimSuffix "/" .Values.APP_BASE_PATH) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent-portal.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-portal.labels" . | nindent 4 }}
+  annotations:
+    secret.reloader.stakater.com/reload: {{ include "agent-portal.secretName" . | quote }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  # 避免更新期间新旧 Pod 的 IM 长连接短暂并存。
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "agent-portal.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "agent-portal.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: db-init
+          image: {{ include "agent-portal.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["node", "apps/server/dist/db/init.js", "--startup-sync"]
+          volumeMounts:
+            - mountPath: /app/apps/server/.env
+              name: config
+              subPath: .env
+      containers:
+        - name: agent-portal
+          image: {{ include "agent-portal.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NODE_ENV
+              value: production
+            - name: SERVE_WEB
+              value: "true"
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: {{ $healthPath }}
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /app/apps/server/.env
+              name: config
+              subPath: .env
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: config
+          secret:
+            defaultMode: 420
+            secretName: {{ include "agent-portal.secretName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/incubator/agent-portal/templates/deployment.yaml
+++ b/incubator/agent-portal/templates/deployment.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agent-portal.labels" . | nindent 4 }}
-  annotations:
-    secret.reloader.stakater.com/reload: {{ include "agent-portal.secretName" . | quote }}
 spec:
   replicas: {{ .Values.replicaCount }}
   # 避免更新期间新旧 Pod 的 IM 长连接短暂并存。
@@ -23,10 +21,12 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- /* Secret 以 subPath 挂载，kubelet 不会热更新；用 checksum 触发滚动更新 */}}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/incubator/agent-portal/templates/ingress.yaml
+++ b/incubator/agent-portal/templates/ingress.yaml
@@ -17,7 +17,7 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-    {{- if and $host (eq $.Values.scheme "https") }}
+    {{- if $host }}
     - host: {{ $host | quote }}
       http:
     {{- else }}
@@ -31,7 +31,7 @@ spec:
                 name: {{ include "agent-portal.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
-  {{- if and .Values.ingress.tls $host }}
+  {{- if and .Values.ingress.tls $host (eq .Values.scheme "https") }}
   tls:
     - hosts:
         - {{ $host | quote }}

--- a/incubator/agent-portal/templates/ingress.yaml
+++ b/incubator/agent-portal/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled -}}
+{{- $host := .Values.ingress.host | default .Values.clb -}}
+{{- $tlsSecret := .Values.ingress.tlsSecretName | default (printf "%s-secret" $host) -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agent-portal.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-portal.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- if and $host (eq $.Values.scheme "https") }}
+    - host: {{ $host | quote }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "agent-portal.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+  {{- if and .Values.ingress.tls $host }}
+  tls:
+    - hosts:
+        - {{ $host | quote }}
+      secretName: {{ $tlsSecret | quote }}
+  {{- end }}
+{{- end }}

--- a/incubator/agent-portal/templates/ingress.yaml
+++ b/incubator/agent-portal/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $host := .Values.ingress.host | default .Values.clb -}}
-{{- $tlsSecret := .Values.ingress.tlsSecretName | default (printf "%s-secret" $host) -}}
+{{- $clbScheme := default .Values.scheme .Values.clbScheme -}}
+{{- $tlsSecret := .Values.ingress.tlsSecretName | default (printf "%s-clb-cert" (include "agent-portal.fullname" .)) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -8,10 +9,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agent-portal.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    ingress.cloud.tencent.com/direct-access: "true"
+    {{- if .Values.clbId }}
+    kubernetes.io/ingress.existLbId: {{ .Values.clbId | quote }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- with .Values.ingress.className }}
   ingressClassName: {{ . }}
@@ -31,7 +36,7 @@ spec:
                 name: {{ include "agent-portal.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
-  {{- if and .Values.ingress.tls $host (eq .Values.scheme "https") }}
+  {{- if and .Values.ingress.tls $host (eq $clbScheme "https") }}
   tls:
     - hosts:
         - {{ $host | quote }}

--- a/incubator/agent-portal/templates/service.yaml
+++ b/incubator/agent-portal/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent-portal.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-portal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: http
+  selector:
+    {{- include "agent-portal.selectorLabels" . | nindent 4 }}
+  sessionAffinity: None

--- a/incubator/agent-portal/values.schema.json
+++ b/incubator/agent-portal/values.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Agent Portal Helm values",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "required": ["repository", "pullPolicy", "tag"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "scheme": {
+      "type": "string",
+      "enum": ["http", "https"]
+    },
+    "clb": {
+      "type": "string",
+      "pattern": "^$|^[A-Za-z0-9.-]+$"
+    },
+    "adp": {
+      "type": "object",
+      "required": ["apiEndpoint", "chatEndpoint", "host"],
+      "properties": {
+        "apiEndpoint": {
+          "type": "string"
+        },
+        "chatEndpoint": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "required": ["type", "port"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "required": ["enabled", "path", "pathType", "tls"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^/"
+        },
+        "pathType": {
+          "type": "string",
+          "enum": ["ImplementationSpecific", "Prefix", "Exact"]
+        },
+        "tls": {
+          "type": "boolean"
+        }
+      }
+    },
+    "APP_BASE_PATH": {
+      "type": "string",
+      "pattern": "^$|^/[^?#\\s]*$"
+    },
+    "LOG_LEVEL": {
+      "type": "string",
+      "enum": ["trace", "debug", "info", "warn", "error", "fatal"]
+    },
+    "db": {
+      "type": "object",
+      "required": ["host", "port", "user", "password", "type", "name", "connectionLimit"],
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["mysql", "tdsql"]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "connectionLimit": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "required": ["type", "bucket", "region", "endpoint", "accessKey", "secretKey", "forcePathStyle"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["s3", "local"]
+        },
+        "bucket": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "accessKey": {
+          "type": "string"
+        },
+        "secretKey": {
+          "type": "string"
+        },
+        "forcePathStyle": {
+          "type": "string",
+          "enum": ["true", "false"]
+        }
+      }
+    },
+    "AUTH_GENERIC_OAUTH_TOKEN_AUTH_METHOD": {
+      "type": "string",
+      "enum": ["client_secret_post", "client_secret_basic"]
+    },
+    "AUTH_GENERIC_OAUTH_USER_INFO_AUTH_METHOD": {
+      "type": "string",
+      "enum": ["query", "bearer"]
+    },
+    "LOGIN_CAPTCHA_PROVIDER": {
+      "type": "string",
+      "enum": ["cap", "slider", "character"]
+    },
+    "LICENSE_MODE": {
+      "type": "string",
+      "enum": ["adp", "private"]
+    }
+  }
+}

--- a/incubator/agent-portal/values.schema.json
+++ b/incubator/agent-portal/values.schema.json
@@ -32,6 +32,17 @@
       "type": "string",
       "pattern": "^$|^[A-Za-z0-9.-]+$"
     },
+    "clbId": {
+      "type": "string",
+      "pattern": "^$|^lb-[A-Za-z0-9]+$"
+    },
+    "clbScheme": {
+      "type": "string",
+      "enum": ["http", "https"]
+    },
+    "clbCertId": {
+      "type": "string"
+    },
     "adp": {
       "type": "object",
       "required": ["apiEndpoint", "chatEndpoint", "host"],

--- a/incubator/agent-portal/values.yaml
+++ b/incubator/agent-portal/values.yaml
@@ -1,0 +1,251 @@
+# Agent Portal - 对外配置
+#
+# 配置分为两部分：
+#   1. 必填配置：安装前必须逐项修改，占位符形如 <YOUR_XXX>
+#   2. 可选配置：保持默认即可正常启动，按需调整
+#
+# 快速配置清单（最少需要修改以下 8 项）：
+#   clb / db.host / db.user / db.password
+#   storage.bucket / storage.region / storage.accessKey / storage.secretKey
+#   以及 PORTAL_CREDENTIALS_KEY、BETTER_AUTH_SECRET 两个密钥
+
+# ============================================================
+# 一、必填配置
+# ============================================================
+
+# ---------- 对外访问 ----------
+# Portal 对外访问域名（必填），不含协议和路径
+# 需要给 CLB 绑定一个自定义域名 https://console.cloud.tencent.com/clb/instance
+clb: "xx-portal.example.com"
+# 平台访问协议：http 或 https（必填）
+# 使用 https 时需提前在集群中创建 TLS 证书 Secret https://console.cloud.tencent.com/ssl
+scheme: https
+
+# ---------- 数据库（必填）----------
+# 支持 MySQL 8.0+ 或 TDSQL-MySQL，需与 TKE 集群同地域
+#   MySQL: https://console.cloud.tencent.com/cdb/instance
+#   TDSQL: https://console.cloud.tencent.com/tdsqld/instance-tdmysql
+# 要求：字符集 UTF8MB4、lower_case_table_names=1、提前创建库与授权用户
+db:
+  # 数据库主机地址，必须可从 TKE 集群内访问
+  host: "192.168.0.1"
+  # 数据库端口
+  port: 3306
+  # 数据库用户名，需对下方 name 指定的库有建表权限
+  user: "<YOUR_DB_USER>"
+  # 数据库密码
+  password: "<YOUR_DB_PASSWORD>"
+  # 数据库名称，容器启动时 db-init 会自动初始化或迁移该库
+  name: agent_portal
+  # 数据库兼容模式：mysql 或 tdsql
+  type: mysql
+  # MySQL 连接池上限，IM 长连接与调度器会长期占用 leader lock 连接，不建议低于 50
+  connectionLimit: 50
+
+# ---------- 对象存储（必填）----------
+# 用于存放头像、会话附件等文件，建议与 TKE 集群同地域
+# COS 控制台：https://console.cloud.tencent.com/cos
+storage:
+  # 存储类型：s3（COS / MinIO 等 S3 兼容存储）或 local（仅测试用，Pod 重建后文件丢失）
+  type: "s3"
+  # Bucket 名称，COS 需带 APPID 后缀，例如 portal-1250000000
+  bucket: "<YOUR_COS_BUCKET>"
+  # Bucket 所在地域，例如 ap-guangzhou
+  region: "<YOUR_COS_REGION>"
+  # 访问 Endpoint；留空时自动使用 https://cos.<region>.myqcloud.com
+  # 对接自建 MinIO 时填写完整地址，例如 http://minio.default.svc.cluster.local:9000
+  endpoint: ""
+  # COS SecretId 或 MinIO Access Key
+  accessKey: "<YOUR_SECRET_ID>"
+  # COS SecretKey 或 MinIO Secret Key
+  secretKey: "<YOUR_SECRET_KEY>"
+  # 路径风格寻址：COS 填 false，自建 MinIO 填 true
+  forcePathStyle: "false"
+
+# ---------- 应用安全密钥（必填）----------
+# 以下密钥写入 Kubernetes Secret，不会进入 ConfigMap
+# 生成方法：openssl rand -base64 32
+#
+# 注意：PORTAL_CREDENTIALS_KEY 用于 IM / Connector 凭据的 AES-256-GCM 加密。
+# 已有存量数据的环境升级时必须沿用原值，重新生成会导致历史凭据无法解密。
+PORTAL_CREDENTIALS_KEY: "<YOUR_PORTAL_CREDENTIALS_KEY>"
+# Better Auth 用于加密登录 session 的密钥
+BETTER_AUTH_SECRET: "<YOUR_BETTER_AUTH_SECRET>"
+
+# ============================================================
+# 二、可选配置（保持默认即可正常启动）
+# ============================================================
+
+# ---------- 应用基础 ----------
+# 应用部署子路径，必须与 ingress.path 保持一致；部署到根路径时两者分别设为 "" 和 /
+APP_BASE_PATH: "/agent-portal"
+# 日志级别：trace / debug / info / warn / error / fatal
+LOG_LEVEL: "info"
+# 日志美化，仅开发环境生效，生产环境建议 false
+LOG_PRETTY: "false"
+
+# ---------- 镜像 ----------
+image:
+  # 镜像仓库地址（勿动）
+  repository: ccr.ccs.tencentyun.com/tke-market/agent-portal
+  # 镜像标签；留空时使用 Chart.yaml 中的 appVersion
+  # 当前镜像仅支持 linux/amd64，集群含 ARM 节点时请配合下方 nodeSelector 约束调度
+  tag: "tke-market-license-dev-67799082-20260805-143502-amd64"
+  # 镜像拉取策略：Always / IfNotPresent / Never
+  pullPolicy: Always
+
+# 私有镜像仓库拉取凭据，例如：[{ name: ccr-registry }]
+imagePullSecrets: []
+
+# ---------- 工作负载 ----------
+# Deployment 副本数，生产环境建议至少 2
+# IM 长连接的单写由数据库 leader lock 保证，多副本安全
+replicaCount: 2
+
+# Pod 资源请求与上限
+resources:
+  limits:
+    cpu: "2"
+    memory: 4Gi
+  requests:
+    cpu: "1"
+    memory: 2Gi
+
+# ---------- Service ----------
+service:
+  # Service 类型：ClusterIP / NodePort / LoadBalancer
+  # 集群未开启负载均衡直连 Pod 模式时，配合 Ingress 需改为 NodePort
+  # 详见 https://cloud.tencent.com/document/product/457/41897
+  type: ClusterIP
+  # Service 端口，同时作为容器监听端口
+  port: 4000
+
+# ---------- Ingress ----------
+ingress:
+  # 是否创建 Ingress
+  enabled: true
+  # IngressClass 名称，TKE 通常为 qcloud
+  className: qcloud
+  # 网关读写超时，SSE 长会话需要放宽，不建议调小
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
+  # Ingress 域名；留空时复用上方 clb
+  host: ""
+  # 路由路径，必须与 APP_BASE_PATH 保持一致
+  path: /agent-portal
+  # 路径匹配类型：ImplementationSpecific / Prefix / Exact
+  pathType: ImplementationSpecific
+  # 是否配置 TLS，仅在已准备证书 Secret 时开启
+  tls: true
+  # TLS Secret 名称；留空时使用 <host>-secret
+  tlsSecretName: ""
+
+# ---------- ADP 接入 ----------
+# Portal 与 ADP 共用同一域名时无需配置；使用独立 ADP 地址时按实际填写
+adp:
+  # ADP 云 API 地址，支持 host 或完整 URL；留空时使用 clb
+  apiEndpoint: ""
+  # ADP 对话 SSE 完整地址；留空时使用 <scheme>://<clb>/adp/v2/chat
+  chatEndpoint: ""
+  # 门户展示与同步时写入的 ADP Host；留空时使用 <scheme>://<clb>
+  host: ""
+
+# ---------- License ----------
+# 授权模式：adp（ADP 激活码）或 private（独立授权服务）
+LICENSE_MODE: "adp"
+# adp 模式的校验地址；留空时自动使用 <scheme>://<clb>/cgi/apex/test/adp/platform/CheckLicense
+LICENSE_HOST_ADP: ""
+# License 提示语言：zh 或 en
+LICENSE_LANGUAGE: "zh"
+
+# ---------- 登录与功能开关 ----------
+# 是否启用登录图形验证码
+LOGIN_CAPTCHA_ENABLED: "true"
+# 验证码提供方：cap / slider / character
+LOGIN_CAPTCHA_PROVIDER: "cap"
+# 是否要求验证码两次请求的来源 IP 一致
+# CGNAT、多层负载均衡等出口 IP 会变化的场景需设为 false
+LOGIN_CAPTCHA_CHECK_IP: "false"
+# 多智能体协同编排总开关
+FEATURE_ORCHESTRATION: "true"
+
+# ---------- 履约执行超时（毫秒）----------
+# 智能体履约超时
+FULFILLMENT_AGENT_TIMEOUT_MS: "30000"
+# 模型履约超时
+FULFILLMENT_MODEL_TIMEOUT_MS: "30000"
+# API 履约超时
+FULFILLMENT_API_TIMEOUT_MS: "15000"
+
+# ---------- 邮件服务 ----------
+# 用于邮箱验证与密码重置；SMTP_HOST 为空时邮件功能不可用
+SMTP_HOST: ""
+SMTP_PORT: "587"
+SMTP_USER: ""
+SMTP_PASS: ""
+# 发件人地址，例如 noreply@example.com
+SMTP_FROM: ""
+
+# ---------- 单点登录（三选一，均可选）----------
+# 未配置任何 SSO 时使用账号密码登录
+
+# 钉钉 SSO：Client ID 与 Secret 需成组配置
+AUTH_DINGTALK_CLIENT_ID: ""
+AUTH_DINGTALK_CLIENT_SECRET: ""
+# 钉钉开放平台登记的完整回调 URL，例如 https://portal.example.com/api/auth/callback/dingtalk
+AUTH_DINGTALK_CALLBACK_URL: ""
+# 钉钉 OAuth scope
+AUTH_DINGTALK_SCOPE: "openid Contact.User.Read"
+# 钉钉未返回企业邮箱时使用的合成邮箱域名
+AUTH_DINGTALK_EMAIL_DOMAIN: "sso.local"
+
+# ADP OAuth2 IdP：Base URL、Client ID 与 Secret 需成组配置
+AUTH_ADP_OAUTH_BASE_URL: ""
+AUTH_ADP_OAUTH_CLIENT_ID: ""
+AUTH_ADP_OAUTH_CLIENT_SECRET: ""
+# 完整回调 URL，例如 https://portal.example.com/api/auth/callback/adp
+AUTH_ADP_OAUTH_CALLBACK_URL: ""
+# IdP 未返回邮箱时使用的合成邮箱域名
+AUTH_ADP_OAUTH_EMAIL_DOMAIN: "adp.local"
+
+# 通用 OAuth2 SSO：Client ID、Secret 与三个端点需成组配置
+AUTH_GENERIC_OAUTH_CLIENT_ID: ""
+AUTH_GENERIC_OAUTH_CLIENT_SECRET: ""
+AUTH_GENERIC_OAUTH_AUTHORIZATION_URL: ""
+AUTH_GENERIC_OAUTH_TOKEN_URL: ""
+AUTH_GENERIC_OAUTH_USER_INFO_URL: ""
+# 请求 scope，多个值用空格分隔
+AUTH_GENERIC_OAUTH_SCOPES: "read all"
+# Token 端点认证方式：client_secret_post 或 client_secret_basic
+AUTH_GENERIC_OAUTH_TOKEN_AUTH_METHOD: "client_secret_post"
+# 追加到授权请求的参数，URL 查询字符串格式
+AUTH_GENERIC_OAUTH_AUTHORIZATION_PARAMS: "approval_prompt=auto"
+# 用户信息请求认证方式：query 或 bearer
+AUTH_GENERIC_OAUTH_USER_INFO_AUTH_METHOD: "query"
+# query 模式下携带 access token 的参数名
+AUTH_GENERIC_OAUTH_USER_INFO_TOKEN_PARAM: "access_token"
+# 用户信息响应的字段映射，按 IdP 实际返回结构调整
+AUTH_GENERIC_OAUTH_USER_ID_FIELD: "userId"
+AUTH_GENERIC_OAUTH_EMAIL_FIELD: "email"
+AUTH_GENERIC_OAUTH_NAME_FIELD: "realname"
+AUTH_GENERIC_OAUTH_USERNAME_FIELD: "username"
+AUTH_GENERIC_OAUTH_DEPARTMENT_FIELD: "department"
+# IdP 未返回邮箱时使用的合成邮箱域名
+AUTH_GENERIC_OAUTH_EMAIL_DOMAIN: "sso.local"
+
+# Customer 免密登录签名密钥；未启用 Customer 登录时留空
+# 生成方法：openssl rand -base64 32
+AUTH_CUSTOMER_SECRET_KEY: ""
+
+# ---------- Pod 元数据与调度 ----------
+# 附加到 Pod 的注解
+podAnnotations: {}
+# 附加到 Pod 的标签
+podLabels: {}
+# 节点选择器
+nodeSelector: {}
+# 污点容忍
+tolerations: []
+# 亲和性 / 反亲和性
+affinity: {}

--- a/incubator/agent-portal/values.yaml
+++ b/incubator/agent-portal/values.yaml
@@ -4,10 +4,13 @@
 #   1. 必填配置：安装前必须逐项修改，占位符形如 <YOUR_XXX>
 #   2. 可选配置：保持默认即可正常启动，按需调整
 #
-# 快速配置清单（最少需要修改以下 8 项）：
-#   clb / db.host / db.user / db.password
+# 快速配置清单（最少需要修改以下项）：
+#   clb / clbId / scheme / clbScheme / clbCertId（https 时）
+#   db.host / db.user / db.password
 #   storage.bucket / storage.region / storage.accessKey / storage.secretKey
 #   以及 PORTAL_CREDENTIALS_KEY、BETTER_AUTH_SECRET 两个密钥
+#
+# CLB 相关字段对齐 ADP Chart（global.clb / clbId / scheme / clbScheme / clbCertId）
 
 # ============================================================
 # 一、必填配置
@@ -17,9 +20,21 @@
 # Portal 对外访问域名（必填），不含协议和路径
 # 需要给 CLB 绑定一个自定义域名 https://console.cloud.tencent.com/clb/instance
 clb: "xx-portal.example.com"
+# CLB ID（必填），写入 Ingress 注解 kubernetes.io/ingress.existLbId，绑定已有 CLB
+# https://console.cloud.tencent.com/clb/instance
+clbId: lb-example
 # 平台访问协议：http 或 https（必填）
-# 使用 https 时需提前在集群中创建 TLS 证书 Secret https://console.cloud.tencent.com/ssl
+# 用于拼接 PORTAL_PUBLIC_URL / CLIENT_ORIGIN 等应用侧对外地址
 scheme: https
+# CLB 监听协议：http 或 https（必填，默认与 scheme 保持一致）
+# 适用场景：CLB 与后端之间存在协议卸载（SSL Offload）
+# 例如：客户端 https 访问 CLB，CLB 以 http 转发到后端 → scheme=https，clbScheme=http
+clbScheme: https
+# CLB HTTPS 证书 ID（clbScheme 为 https 时必填）
+# Chart 会自动创建 Secret <release>-agent-portal-clb-cert（key: qcloud_cert_id）供 TKE Ingress 使用
+# 已通过 ingress.tlsSecretName 指定现成证书 Secret 时，本项可留空
+# https://console.cloud.tencent.com/ssl
+clbCertId: "<YOUR_CLB_CERT_ID>"
 
 # ---------- 数据库（必填）----------
 # 支持 MySQL 8.0+ 或 TDSQL-MySQL，需与 TKE 集群同地域
@@ -126,19 +141,20 @@ ingress:
   enabled: true
   # IngressClass 名称，TKE 通常为 qcloud
   className: qcloud
-  # 网关读写超时，SSE 长会话需要放宽，不建议调小
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
+  # 额外 Ingress 注解（可选）。下列注解由模板根据 clbId 自动注入，无需在此重复填写：
+  #   kubernetes.io/ingress.existLbId
+  #   ingress.cloud.tencent.com/direct-access
+  annotations: {}
   # Ingress 域名；留空时复用上方 clb
   host: ""
   # 路由路径，必须与 APP_BASE_PATH 保持一致
   path: /agent-portal
   # 路径匹配类型：ImplementationSpecific / Prefix / Exact
   pathType: ImplementationSpecific
-  # 是否配置 TLS，仅在已准备证书 Secret 时开启
+  # 是否配置 TLS；实际是否挂载 tls 段还取决于 clbScheme（默认与 scheme 一致）为 https
   tls: true
-  # TLS Secret 名称；留空时使用 <host>-secret
+  # TLS Secret 名称；留空时由 clbCertId 自动生成 <release>-agent-portal-clb-cert
+  # 填写后将复用该现成 Secret，Chart 不再创建证书 Secret
   tlsSecretName: ""
 
 # ---------- ADP 接入 ----------


### PR DESCRIPTION
## Summary

Add `incubator/agent-portal` for deploying Agent Portal on TKE.

Agent Portal is an enterprise agent gateway that provides agent onboarding and management, intent routing, multi-agent orchestration, observability, and model management. It can integrate with Tencent Cloud Agent Development Platform (ADP) and other OpenAI-compatible model services.

This chart is adapted from the Agent Portal private-deployment package for the TKE Cloud Marketplace.

### Implementation notes

The chart deploys a single Deployment with a shared frontend/backend image (backend serves web assets via `SERVE_WEB=true`). An initContainer runs database migration and seed initialization.

Design choices:

- **Standalone chart, not an ADP umbrella subchart.** Agent Portal can be deployed independently via its own Ingress, without relying on `lke-ti-gateway` routes.
- **Runtime config rendered as a Secret, not a ConfigMap.** All config is mounted as `.env` at `/app/apps/server/.env`, so DB passwords and COS keys never land in ConfigMaps.
- **`values.yaml` split into required / optional sections.** Required fields sit at the top with `<YOUR_XXX>` placeholders; a minimal install needs about 8 overrides.
- **`values.schema.json` included.** Validates protocol, ports, storage type, license mode, and other enums before install.

External dependencies (MySQL / TDSQL, COS, CLB) are user-provided. The chart does not bundle them; README lists purchase links and requirements.

### Known limitations

The current image is `linux/amd64` only. This is documented in `values.yaml` and README, with a `nodeSelector` example. Multi-arch images will follow in a later release.

Image synced to:
`ccr.ccs.tencentyun.com/tke-market/agent-portal:tke-market-license-dev-67799082-20260805-143502-amd64`

### Test plan

- [x] `helm lint` passes (helm 3.9.0, matching CI)
- [x] `helm template` renders Secret / Service / Deployment / Ingress as expected
- [x] `values.schema.json` rejects invalid enums and type errors before install

### Note

This PR is still a draft. Please mark it ready for review after marketplace review is complete.

---

## 概述

新增 `incubator/agent-portal`，用于在 TKE 上部署 Agent Portal（智能体门户）。

Agent Portal 是面向企业的智能体统一入口，提供智能体接入与管理、意图总控与路由、多智能体协同编排、运行观测以及模型管理等能力，可对接腾讯云智能体开发平台（ADP）及其他 OpenAI 兼容模型服务。

本 Chart 由 Agent Portal 的私有化版本移植而来，针对 TKE 云市场场景重新做了适配。

### 实现说明

Chart 将应用部署为单个 Deployment，前后端同镜像（后端以 `SERVE_WEB=true` 托管前端静态资源），initContainer 负责数据库迁移与初始化。

设计取舍：

- **独立 Chart，不作为 ADP 伞形 Chart 的子 Chart。** Agent Portal 可脱离 ADP 独立部署，通过自身 Ingress 暴露，不依赖 `lke-ti-gateway` 路由。
- **运行时配置渲染为 Secret 而非 ConfigMap。** 所有配置以 `.env` 形式挂载到 `/app/apps/server/.env`，避免数据库密码、COS 密钥等出现在 ConfigMap 中。
- **`values.yaml` 按「必填 / 可选」分段。** 必填项集中在文件顶部并使用 `<YOUR_XXX>` 占位符，用户最少只需修改约 8 项即可完成部署。
- **提供 `values.schema.json`。** 对访问协议、端口范围、存储类型、License 模式等枚举值做安装前校验，避免配置错误在 Pod 启动后才暴露。

外部依赖（MySQL / TDSQL、COS、CLB）均由用户自备，Chart 不内置这些组件，README 中已列出购买入口与规格要求。

### 已知限制

当前镜像仅提供 `linux/amd64` 架构，`values.yaml` 与 README 中已说明，并给出了 `nodeSelector` 约束示例。多架构镜像会在后续版本补充。

镜像已同步至：
`ccr.ccs.tencentyun.com/tke-market/agent-portal:tke-market-license-dev-67799082-20260805-143502-amd64`

### 测试情况

- [x] `helm lint` 通过（helm 3.9.0，与 CI 版本一致）
- [x] `helm template` 渲染通过，Secret / Service / Deployment / Ingress 四类资源输出符合预期
- [x] `values.schema.json` 校验行为已验证，非法枚举值与类型错误均能在安装前拦截

### 备注

此 PR 暂为 draft，市场侧审核就绪后再转为正式 PR。