### PR TITLE
feat(agent-portal): add Agent Portal Helm chart

### DIFF
--- a/incubator/agent-portal/Chart.yaml
+++ b/incubator/agent-portal/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agent-portal
 description: Tencent Cloud Agent Portal - enterprise platform with agent management, intent routing, multi-agent orchestration, observability and model management for TKE.
 type: application
-version: 2.0.0
-appVersion: "2.0.0"
+version: 2.0.1
+appVersion: "2.0.1"
 icon: https://agent-portal-1256076159.cos.ap-guangzhou.myqcloud.com/Portal-Docs20260804161651580.png
 home: https://portal.helloadp.com/
 

--- a/incubator/agent-portal/README.md
+++ b/incubator/agent-portal/README.md
@@ -2,7 +2,7 @@
 
 `agent-portal` 是用于在 TKE 上部署 Agent Portal（智能体门户）的 Helm Chart。
 
-Agent Portal 是面向企业的智能体统一入口，提供智能体接入与管理、意图总控与路由、多智能体协同编排、运行观测以及模型管理等能力，可对接腾讯云智能体开发平台（ADP）及其他 OpenAI 兼容模型服务。
+Agent Portal 是面向企业的智能体统一入口，提供智能体接入与管理、意图总控与路由、多智能体协同编排、运行观测以及模型管理等能力，可对接腾讯云智能体开发平台（ADP）、Dify 及其他 OpenAI 兼容智能体服务。
 
 ## 架构说明
 
@@ -187,43 +187,40 @@ Client ID、Client Secret 与三个端点需成组配置。用户信息字段映
 | podAnnotations | Pod 注解 | {} |
 | podLabels | Pod 标签 | {} |
 
-## 示例
+## 安装
 
-### 最小配置部署
+### 在 TKE 应用市场安装（推荐）
 
-创建 `my-values.yaml`：
+在容器服务控制台进入 **应用市场**，搜索并打开 **Agent Portal**，点击「创建应用」：
 
-```yaml
-clb: "portal.example.com"
-clbId: lb-xxxxxxxx
-scheme: https
-clbScheme: https
-clbCertId: "<YOUR_CLB_CERT_ID>"
+![TKE 应用市场创建 Agent Portal](https://agent-portal-1256076159.cos.ap-guangzhou.myqcloud.com/Portal-DocsClipboard_Screenshot_1786436357.png)
 
-db:
-  host: "10.0.0.10"
-  port: 3306
-  user: "portal"
-  password: "<YOUR_DB_PASSWORD>"
-  type: mysql
+按上图填写：
 
-storage:
-  bucket: "portal-1250000000"
-  region: "ap-guangzhou"
-  accessKey: "<YOUR_COS_SECRET_ID>"
-  secretKey: "<YOUR_COS_SECRET_KEY>"
+1. **名称**：应用实例名，例如 `agent-portal`
+2. **地域 / 集群**：选择目标 TKE 集群
+3. **Namespace**：选择或新建部署命名空间
+4. **Chart 版本**：选择需要的版本
+5. **参数**：右侧编辑框即完整的 `values.yaml`，把占位符替换为实际值即可
 
-PORTAL_CREDENTIALS_KEY: "<openssl rand -base64 32>"
-BETTER_AUTH_SECRET: "<openssl rand -base64 32>"
-```
+参数各字段的含义与默认值见本文「[配置说明](#配置说明)」及 Chart 内的 [`values.yaml`](./values.yaml)，安装前**至少**需要修改：
 
-部署：
+- 对外访问：`clb` / `clbId` / `scheme` / `clbScheme` / `clbCertId`
+- 数据库：`db.host` / `db.user` / `db.password`
+- 对象存储：`storage.bucket` / `storage.region` / `storage.accessKey` / `storage.secretKey`
+- 应用密钥：`PORTAL_CREDENTIALS_KEY` / `BETTER_AUTH_SECRET`（`openssl rand -base64 32` 生成）
+
+填好后点击「创建」，等待应用状态变为已部署，即可通过 `https://<clb>/<APP_BASE_PATH>` 访问；首次进入以超级管理员身份在授权页粘贴激活码完成 License 激活。
+
+### 使用 Helm 命令行安装
+
+也可以直接用本 Chart 安装，参数写入 `my-values.yaml`（字段同上）：
 
 ```bash
 helm install agent-portal . -f my-values.yaml -n agent-portal --create-namespace
 ```
 
-部署完成后访问 `https://portal.example.com/agent-portal`。
+## 示例
 
 ### 部署到根路径
 

--- a/incubator/agent-portal/templates/_helpers.tpl
+++ b/incubator/agent-portal/templates/_helpers.tpl
@@ -62,3 +62,24 @@ Image reference
 {{- define "agent-portal.image" -}}
 {{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
 {{- end }}
+
+{{/*
+Built-in ADP platform-manager RSA public key for activation-code decrypt.
+Users do not need to fill this; leave LICENSE_PUBLIC_KEY empty in values.
+*/}}
+{{- define "agent-portal.defaultLicensePublicKey" -}}
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAurReoU7qNrUu+hVIiCLM
+yXfOUZIODPMuR9xphD8S+/Df8DDj40lVOgU3sh0sghFmkhva71fji+N+a279wsjd
+MDBd5ZO7hBApxOdm82TUVnx1be+PhvIkChDKIbOlZJ+GG/gbZsrbCzR+1yHI6h5u
+DmumU4WRGpBg28/6quJ2nl1GUWJAjNCtGdPozJ0Q2Gm0nq1MrQPf5fjBzxJ2GI83
+iM8We8MyeNQO/iAbr+iUqG1XsjD4QqDUUqcgBYRGexS0HHuGYrDWEUvkBnsgqdpR
+zVgqxxJhsDCz7IiqFaTugJJDIoH2/uPJ4rAwSxko481Li1VCKpQQ6KN2mM7cMEeK
+nGakkgkI0OI5znUgC5vBoprUkEO0pk1JcaIrEnEZm5pZCrBJsSbCLQLbiDReSe7q
+XTO54hyFiHv1huweQB5psL/2O0WvKcSM4H4zgAWSSEatxZ/MKD8ESmjgLcUg6KFo
+8aGyRNJLv3+nE7qMLagJDtt0Gqinutu/SXwurj75+Xb2DQWD5JGvkwvvlt5Muvcd
+2HjdhWqwM5sR37a58YK3Rd/M+XqFpOjgXQ1si3m1CyXGAOscgm4/p5pFBgUOjmfI
+tyqsHyMMdAugX6Duo20FkKZwC/gPtAeNYso/Vxt0wRifIrJZPUkdTTOPcmtx+a+6
++8Dhq8soyKlm51Dc6ia0cUECAwEAAQ==
+-----END PUBLIC KEY-----
+{{- end }}

--- a/incubator/agent-portal/templates/configmap.yaml
+++ b/incubator/agent-portal/templates/configmap.yaml
@@ -150,10 +150,8 @@ stringData:
     #   make pack BUILD_ENABLE_LICENSE=true
     #   make push BUILD_ENABLE_LICENSE=true
     LICENSE_MODE={{ .Values.LICENSE_MODE }}
-    # 复用 platform-manager 的 RSA 公钥，支持 \n 形式的单行 PEM
-    {{- with .Values.LICENSE_PUBLIC_KEY }}
-    LICENSE_PUBLIC_KEY={{ . | trim | replace "\n" "\\n" | quote }}
-    {{- end }}
+    {{- $licensePublicKey := .Values.LICENSE_PUBLIC_KEY | default (include "agent-portal.defaultLicensePublicKey" .) }}
+    LICENSE_PUBLIC_KEY={{ $licensePublicKey | trim | replace "\n" "\\n" | quote }}
     # 默认走公网 ADP 正式环境 CheckLicense；测试环境可在 values 覆盖为 .../cgi/apex/test/adp/platform/CheckLicense
     LICENSE_HOST_ADP={{ .Values.LICENSE_HOST_ADP | default "https://adp.cloud.tencent.com/cgi/apex/adp/platform/CheckLicense" | quote }}
     # ProductType 固定校验为 4，服务端不再读取 LICENSE_PRODUCT_TYPE

--- a/incubator/agent-portal/templates/configmap.yaml
+++ b/incubator/agent-portal/templates/configmap.yaml
@@ -144,26 +144,26 @@ stringData:
     # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
     # OTEL_LOG_LEVEL=info
 
-    # ===== License（是否启用由打包时 BUILD_ENABLE_LICENSE 决定） =====
+    # ===== License（专有云固定 ADP 激活码模式；是否启用由打包时 BUILD_ENABLE_LICENSE 决定） =====
     # 本地开发和普通构建默认不启用 License。
     # 如需启用，请在构建阶段传入 BUILD_ENABLE_LICENSE=true，例如：
     #   make pack BUILD_ENABLE_LICENSE=true
     #   make push BUILD_ENABLE_LICENSE=true
-    # 模式选择：
-    # - adp     = 专有云 / ADP 激活码模式
-    # - private = 私有化 / 授权服务模式
-    # 优先读取 LICENSE_MODE；LICENSE_STRATEGY 作为兼容别名保留
     LICENSE_MODE={{ .Values.LICENSE_MODE }}
-    # LICENSE_STRATEGY=adp
-    # ===== 专有云 / ADP 激活码模式 =====
     # 复用 platform-manager 的 RSA 公钥，支持 \n 形式的单行 PEM
-    # LICENSE_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----
-    LICENSE_HOST_ADP={{ .Values.LICENSE_HOST_ADP | default (printf "%s://%s/cgi/apex/test/adp/platform/CheckLicense" .Values.scheme .Values.clb) }}
+    {{- with .Values.LICENSE_PUBLIC_KEY }}
+    LICENSE_PUBLIC_KEY={{ . | trim | replace "\n" "\\n" | quote }}
+    {{- end }}
+    # 默认走公网 ADP 正式环境 CheckLicense；测试环境可在 values 覆盖为 .../cgi/apex/test/adp/platform/CheckLicense
+    LICENSE_HOST_ADP={{ .Values.LICENSE_HOST_ADP | default "https://adp.cloud.tencent.com/cgi/apex/adp/platform/CheckLicense" | quote }}
     # ProductType 固定校验为 4，服务端不再读取 LICENSE_PRODUCT_TYPE
-    # 可选：手动指定实例 ID；不填时会在集群内自动读取 kube-system namespace UID
-    # LICENSE_INSTANCE_ID=
+    # 可选：手动指定实例 ID；不填时会在集群内自动读取 kube-system namespace UID（依赖 Chart 创建的 RBAC）
+    {{- with .Values.LICENSE_INSTANCE_ID }}
+    LICENSE_INSTANCE_ID={{ . | quote }}
+    {{- end }}
     # 可选：后台自动续期任务间隔，最小 60000（默认 900000）
     # LICENSE_RENEW_INTERVAL_MS=900000
+    LICENSE_LANGUAGE={{ .Values.LICENSE_LANGUAGE }}
 
     # ===== 默认对话 LLM（未选择智能体时使用） =====
     # LLM_SYSTEM_PROMPT=你是一个有帮助的智能助手。
@@ -496,21 +496,6 @@ stringData:
     # 是否开启验证码 IP 一致性校验（默认 true）
     # 在 CGNAT / 负载均衡 / 代理等场景下，用户两次请求的出口 IP 可能不同，设为 false 可关闭
     LOGIN_CAPTCHA_CHECK_IP={{ .Values.LOGIN_CAPTCHA_CHECK_IP }}
-    # ===== 私有化 / 授权服务模式 =====
-    # 仅当 LICENSE_MODE=private 时生效；TKE 部署使用 adp 模式，以下取值固定
-    LICENSE_SERVER_URL=
-    LICENSE_SPU_CODE=spu_tencent_cloud_agent_development_platform_subscription_license
-    LICENSE_PRICING_CODE=standard_edition_private_cloud_subscription_license
-    LICENSE_RULE_KEY=adp_agent_count
-    LICENSE_AUTH_TYPE=NODE_RESTRICTED
-    LICENSE_LANGUAGE={{ .Values.LICENSE_LANGUAGE }}
-
-    # 许可证跳过令牌（可选，用于无许可证服务器的场景）
-    # 仅当 LICENSE_MODE=private 时生效
-    # 不配置 LICENSE_SERVER_URL 时，若也不配置此项，则所有写操作被拦截
-    # 此 token 由开发方使用 RSA 私钥签名生成，客户无法自行生成
-    # 需要时请联系开发方获取
-    # LICENSE_BYPASS_TOKEN=
 
     # ===== Observability · 外部 DLP / 安全平台事件接收 =====
     # 用于 POST /api/observability/security-event 的 Bearer token 鉴权

--- a/incubator/agent-portal/templates/rbac-license.yaml
+++ b/incubator/agent-portal/templates/rbac-license.yaml
@@ -1,0 +1,28 @@
+{{- if not .Values.LICENSE_INSTANCE_ID }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "agent-portal.fullname" . }}-license-instance
+  labels:
+    {{- include "agent-portal.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    resourceNames: ["kube-system"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "agent-portal.fullname" . }}-license-instance
+  labels:
+    {{- include "agent-portal.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "agent-portal.fullname" . }}-license-instance
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/agent-portal/values.schema.json
+++ b/incubator/agent-portal/values.schema.json
@@ -176,7 +176,20 @@
     },
     "LICENSE_MODE": {
       "type": "string",
-      "enum": ["adp", "private"]
+      "enum": ["adp"]
+    },
+    "LICENSE_HOST_ADP": {
+      "type": "string"
+    },
+    "LICENSE_PUBLIC_KEY": {
+      "type": "string"
+    },
+    "LICENSE_INSTANCE_ID": {
+      "type": "string"
+    },
+    "LICENSE_LANGUAGE": {
+      "type": "string",
+      "enum": ["zh", "en"]
     }
   }
 }

--- a/incubator/agent-portal/values.yaml
+++ b/incubator/agent-portal/values.yaml
@@ -9,6 +9,7 @@
 #   db.host / db.user / db.password
 #   storage.bucket / storage.region / storage.accessKey / storage.secretKey
 #   以及 PORTAL_CREDENTIALS_KEY、BETTER_AUTH_SECRET 两个密钥
+#   LICENSE_PUBLIC_KEY / LICENSE_HOST_ADP 默认已可用，部署后粘贴激活码即可
 #
 # CLB 相关字段对齐 ADP Chart（global.clb / clbId / scheme / clbScheme / clbCertId）
 
@@ -168,10 +169,34 @@ adp:
   host: ""
 
 # ---------- License ----------
-# 授权模式：adp（ADP 激活码）或 private（独立授权服务）
+# 专有云固定为 ADP 激活码模式；部署后在 Portal 授权页粘贴激活码即可
 LICENSE_MODE: "adp"
-# adp 模式的校验地址；留空时自动使用 <scheme>://<clb>/cgi/apex/test/adp/platform/CheckLicense
+# ADP CheckLicense 地址
+# 留空时默认使用公网 ADP 正式环境：https://adp.cloud.tencent.com/cgi/apex/adp/platform/CheckLicense
+# 联调/测试环境可改为 https://adp.cloud.tencent.com/cgi/apex/test/adp/platform/CheckLicense
+# 若 Portal 与专有云 ADP 共用同一入口且已暴露该路径，可改为 <scheme>://<clb>/cgi/apex/adp/platform/CheckLicense
 LICENSE_HOST_ADP: ""
+# ADP / platform-manager 的 RSA 公钥，用于解密用户粘贴的激活码
+# 支持多行 PEM；Chart 写入 .env 时会自动转为 \n 单行形式
+# 默认值与 ADP platform-manager 的 PUBLIC_KEY 对齐；若研发另行下发公钥请覆盖本项
+LICENSE_PUBLIC_KEY: |
+  -----BEGIN PUBLIC KEY-----
+  MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAurReoU7qNrUu+hVIiCLM
+  yXfOUZIODPMuR9xphD8S+/Df8DDj40lVOgU3sh0sghFmkhva71fji+N+a279wsjd
+  MDBd5ZO7hBApxOdm82TUVnx1be+PhvIkChDKIbOlZJ+GG/gbZsrbCzR+1yHI6h5u
+  DmumU4WRGpBg28/6quJ2nl1GUWJAjNCtGdPozJ0Q2Gm0nq1MrQPf5fjBzxJ2GI83
+  iM8We8MyeNQO/iAbr+iUqG1XsjD4QqDUUqcgBYRGexS0HHuGYrDWEUvkBnsgqdpR
+  zVgqxxJhsDCz7IiqFaTugJJDIoH2/uPJ4rAwSxko481Li1VCKpQQ6KN2mM7cMEeK
+  nGakkgkI0OI5znUgC5vBoprUkEO0pk1JcaIrEnEZm5pZCrBJsSbCLQLbiDReSe7q
+  XTO54hyFiHv1huweQB5psL/2O0WvKcSM4H4zgAWSSEatxZ/MKD8ESmjgLcUg6KFo
+  8aGyRNJLv3+nE7qMLagJDtt0Gqinutu/SXwurj75+Xb2DQWD5JGvkwvvlt5Muvcd
+  2HjdhWqwM5sR37a58YK3Rd/M+XqFpOjgXQ1si3m1CyXGAOscgm4/p5pFBgUOjmfI
+  tyqsHyMMdAugX6Duo20FkKZwC/gPtAeNYso/Vxt0wRifIrJZPUkdTTOPcmtx+a+6
+  +8Dhq8soyKlm51Dc6ia0cUECAwEAAQ==
+  -----END PUBLIC KEY-----
+# 可选：手动指定 License 实例 ID；留空时由 Pod 读取 kube-system namespace UID
+# Chart 会创建最小权限 RBAC（get namespaces/kube-system）；若集群策略禁止该权限，请显式填写本项
+LICENSE_INSTANCE_ID: ""
 # License 提示语言：zh 或 en
 LICENSE_LANGUAGE: "zh"
 

--- a/incubator/agent-portal/values.yaml
+++ b/incubator/agent-portal/values.yaml
@@ -9,7 +9,6 @@
 #   db.host / db.user / db.password
 #   storage.bucket / storage.region / storage.accessKey / storage.secretKey
 #   以及 PORTAL_CREDENTIALS_KEY、BETTER_AUTH_SECRET 两个密钥
-#   LICENSE_PUBLIC_KEY / LICENSE_HOST_ADP 默认已可用，部署后粘贴激活码即可
 #
 # CLB 相关字段对齐 ADP Chart（global.clb / clbId / scheme / clbScheme / clbCertId）
 
@@ -174,28 +173,11 @@ LICENSE_MODE: "adp"
 # ADP CheckLicense 地址
 # 留空时默认使用公网 ADP 正式环境：https://adp.cloud.tencent.com/cgi/apex/adp/platform/CheckLicense
 # 联调/测试环境可改为 https://adp.cloud.tencent.com/cgi/apex/test/adp/platform/CheckLicense
-# 若 Portal 与专有云 ADP 共用同一入口且已暴露该路径，可改为 <scheme>://<clb>/cgi/apex/adp/platform/CheckLicense
 LICENSE_HOST_ADP: ""
-# ADP / platform-manager 的 RSA 公钥，用于解密用户粘贴的激活码
-# 支持多行 PEM；Chart 写入 .env 时会自动转为 \n 单行形式
-# 默认值与 ADP platform-manager 的 PUBLIC_KEY 对齐；若研发另行下发公钥请覆盖本项
-LICENSE_PUBLIC_KEY: |
-  -----BEGIN PUBLIC KEY-----
-  MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAurReoU7qNrUu+hVIiCLM
-  yXfOUZIODPMuR9xphD8S+/Df8DDj40lVOgU3sh0sghFmkhva71fji+N+a279wsjd
-  MDBd5ZO7hBApxOdm82TUVnx1be+PhvIkChDKIbOlZJ+GG/gbZsrbCzR+1yHI6h5u
-  DmumU4WRGpBg28/6quJ2nl1GUWJAjNCtGdPozJ0Q2Gm0nq1MrQPf5fjBzxJ2GI83
-  iM8We8MyeNQO/iAbr+iUqG1XsjD4QqDUUqcgBYRGexS0HHuGYrDWEUvkBnsgqdpR
-  zVgqxxJhsDCz7IiqFaTugJJDIoH2/uPJ4rAwSxko481Li1VCKpQQ6KN2mM7cMEeK
-  nGakkgkI0OI5znUgC5vBoprUkEO0pk1JcaIrEnEZm5pZCrBJsSbCLQLbiDReSe7q
-  XTO54hyFiHv1huweQB5psL/2O0WvKcSM4H4zgAWSSEatxZ/MKD8ESmjgLcUg6KFo
-  8aGyRNJLv3+nE7qMLagJDtt0Gqinutu/SXwurj75+Xb2DQWD5JGvkwvvlt5Muvcd
-  2HjdhWqwM5sR37a58YK3Rd/M+XqFpOjgXQ1si3m1CyXGAOscgm4/p5pFBgUOjmfI
-  tyqsHyMMdAugX6Duo20FkKZwC/gPtAeNYso/Vxt0wRifIrJZPUkdTTOPcmtx+a+6
-  +8Dhq8soyKlm51Dc6ia0cUECAwEAAQ==
-  -----END PUBLIC KEY-----
+# 解密激活码的 RSA 公钥：默认由 Chart 内置（与 ADP platform-manager 对齐），安装时无需填写
+# 仅当研发另行下发公钥时再覆盖本项
+LICENSE_PUBLIC_KEY: ""
 # 可选：手动指定 License 实例 ID；留空时由 Pod 读取 kube-system namespace UID
-# Chart 会创建最小权限 RBAC（get namespaces/kube-system）；若集群策略禁止该权限，请显式填写本项
 LICENSE_INSTANCE_ID: ""
 # License 提示语言：zh 或 en
 LICENSE_LANGUAGE: "zh"


### PR DESCRIPTION
## Summary

- Add `incubator/agent-portal` for deploying Agent Portal (enterprise agent portal) on TKE.
- Align external access with the ADP chart convention: `clb` / `clbId` / `scheme` / `clbScheme` / `clbCertId`. The chart binds an existing CLB through `kubernetes.io/ingress.existLbId`, and the certificate Secret is prefixed with the release name to avoid colliding with ADP in the same namespace.
- Render all runtime configuration into a Secret mounted as `.env`, so database and object storage credentials never land in a ConfigMap.
- Use the ADP activation-code license mode. The chart ships a default CheckLicense endpoint and public key, and creates a least-privilege RBAC rule (`get namespaces/kube-system`) only when no instance ID is provided.
- Document installation from the TKE app market in the README, with parameter details pointing at the full `values.yaml`.

## Test plan

- [ ] `helm lint` and `helm template` pass, and `values.schema.json` validation takes effect.
- [ ] Install on a TKE test cluster with CLB / MySQL / COS / app secrets filled in; pods reach Running.
- [ ] Ingress binds the existing CLB and the HTTPS domain returns 200.
- [ ] A super admin can paste the activation code on the license page to complete activation.

---

## 概述

- 新增 `incubator/agent-portal`，用于在 TKE 上部署 Agent Portal（企业智能体门户）。
- 对外访问对齐 ADP Chart 约定：`clb` / `clbId` / `scheme` / `clbScheme` / `clbCertId`。通过 `kubernetes.io/ingress.existLbId` 绑定已有 CLB，证书 Secret 带 release 前缀，避免与同命名空间的 ADP 撞名。
- 运行时配置统一渲染到 Secret 并以 `.env` 挂载，数据库与对象存储密钥不会进入 ConfigMap。
- License 采用 ADP 激活码模式。Chart 内置默认 CheckLicense 地址与公钥；仅在未指定实例 ID 时创建最小权限 RBAC（`get namespaces/kube-system`）。
- README 提供 TKE 应用市场安装指引，参数说明指向完整的 `values.yaml`。

## 测试计划

- [ ] `helm lint` 与 `helm template` 通过，`values.schema.json` 校验生效。
- [ ] 在 TKE 测试集群安装：填写 CLB / MySQL / COS / 应用密钥后 Pod 正常 Running。
- [ ] Ingress 绑定已有 CLB，HTTPS 域名访问返回 200。
- [ ] 超级管理员可在授权页粘贴激活码完成 License 激活。