### PR TITLE
tke-extend-network-controller: bump to 2.5.2

### DIFF
--- a/incubator/tke-extend-network-controller/Chart.yaml
+++ b/incubator/tke-extend-network-controller/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.1
+version: 2.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2.5.1
+appVersion: 2.5.2
 kubeVersion: '>= 1.26.0-0'

--- a/incubator/tke-extend-network-controller/templates/deployment.yaml
+++ b/incubator/tke-extend-network-controller/templates/deployment.yaml
@@ -19,10 +19,10 @@ spec:
     spec:
       hostAliases:
       - hostnames:
-        - clb.tencentcloudapi.com
-        - vpc.tencentcloudapi.com
-        - cam.tencentcloudapi.com
-        ip: 169.254.0.95
+        {{- range $svc := list "clb" "vpc" "cam" "tag" }}
+        - {{ $svc }}{{ if $.Values.cloudAPI.endpointSuffix }}.{{ $.Values.cloudAPI.endpointSuffix }}{{ end }}.tencentcloudapi.com
+        {{- end }}
+        ip: {{ .Values.cloudAPI.hostAliasesIP }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -56,6 +56,8 @@ spec:
           value: "{{ .Values.concurrency.clbNodeBindingController }}"
         - name: WORKER_CLB_PORT_POOL_CONTROLLER
           value: "{{ .Values.concurrency.clbPortPoolController }}"
+        - name: CLOUD_API_ENDPOINT_SUFFIX
+          value: "{{ .Values.cloudAPI.endpointSuffix }}"
         - name: WORKER_POD_CONTROLLER
           value: "{{ .Values.concurrency.podController }}"
         - name: WORKER_NODE_CONTROLLER

--- a/incubator/tke-extend-network-controller/templates/networking.cloud.tencent.com_clbnodebindings.yaml
+++ b/incubator/tke-extend-network-controller/templates/networking.cloud.tencent.com_clbnodebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clbnodebindings.networking.cloud.tencent.com
 spec:
   group: networking.cloud.tencent.com
@@ -97,6 +97,11 @@ spec:
                 items:
                   description: PortBindingStatus 描述单个端口的实际绑定情况
                   properties:
+                    addressIPVersion:
+                      description: |-
+                        CLB 的 IP 版本，可选值：IPV4、IPV6、IPv6FullChain
+                        用于确定注册后端时使用 Pod/Node 的 IPv4 还是 IPv6 地址
+                      type: string
                     certId:
                       description: 服务端证书 ID（仅在 TCP_SSL 和 QUIC 协议下有效）
                       type: string

--- a/incubator/tke-extend-network-controller/templates/networking.cloud.tencent.com_clbpodbindings.yaml
+++ b/incubator/tke-extend-network-controller/templates/networking.cloud.tencent.com_clbpodbindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clbpodbindings.networking.cloud.tencent.com
 spec:
   group: networking.cloud.tencent.com
@@ -97,6 +97,11 @@ spec:
                 items:
                   description: PortBindingStatus 描述单个端口的实际绑定情况
                   properties:
+                    addressIPVersion:
+                      description: |-
+                        CLB 的 IP 版本，可选值：IPV4、IPV6、IPv6FullChain
+                        用于确定注册后端时使用 Pod/Node 的 IPv4 还是 IPv6 地址
+                      type: string
                     certId:
                       description: 服务端证书 ID（仅在 TCP_SSL 和 QUIC 协议下有效）
                       type: string

--- a/incubator/tke-extend-network-controller/templates/networking.cloud.tencent.com_clbportpools.yaml
+++ b/incubator/tke-extend-network-controller/templates/networking.cloud.tencent.com_clbportpools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clbportpools.networking.cloud.tencent.com
 spec:
   group: networking.cloud.tencent.com
@@ -153,8 +153,10 @@ spec:
                         - clb.c4.xlarge
                         type: string
                       subnetId:
-                        description: 在私有网络内购买内网负载均衡实例的情况下，必须指定子网 ID，内网负载均衡实例的 VIP
-                          将从这个子网中产生。创建内网负载均衡实例时，此参数必填，创建公网IPv4负载均衡实例时，不支持指定该参数。
+                        description: |-
+                          在私有网络内购买内网负载均衡实例的情况下，必须指定子网 ID，内网负载均衡实例的 VIP 将从这个子网中产生。
+                          创建内网负载均衡实例，或者创建 IPv6FullChain 版本的负载均衡实例，此参数必填。
+                          创建公网IPv4负载均衡实例时，不支持指定该参数。
                         type: string
                       tags:
                         description: 购买负载均衡的同时，给负载均衡打上标签，最大支持20个标签键值对。
@@ -224,7 +226,6 @@ spec:
                   CLB 分配策略，单个端口池中有多个可分配 CLB ，分配端口时 CLB 的挑选策略。
                   可选值：Uniform（均匀分配）、InOrder（顺序分配）、Random（随机分配）。默认值为 Random。
 
-
                   若希望减小 DDoS 攻击的影响，建议使用 Uniform 策略，避免业务使用的 IP 过于集中；若希望提高
                   CLB 的利用率，建议使用 InOrder 策略。
                 enum:
@@ -235,7 +236,6 @@ spec:
               listenerPrecreate:
                 description: |-
                   监听器预创建，预先为 lb 创建一些固定的监听器，不销毁，用于加快扩缩容时 CLB 的绑定和解绑速度。
-
 
                   注意：预创建监听器的端口池只支持 TCP 和 UDP 协议（不支持 TCP_SSL 和 QUIC）。
                 properties:
@@ -268,7 +268,6 @@ spec:
                   监听器数量配额。仅用在单独调整了指定 CLB 实例监听器数量配额的场景（TOTAL_LISTENER_QUOTA），
                   控制器默认会获取账号维度的监听器数量配额作为端口分配的依据，如果 listenerQuota 不为空，
                   将以它的值作为该端口池中所有 CLB 监听器数量配额覆盖账号维度的监听器数量配额。
-
 
                   注意：如果指定了 listenerQuota，不支持启用 CLB 自动创建，且需自行保证该端口池中所有 CLB
                   实例的监听器数量配额均等于 listenerQuota 的值。
@@ -305,6 +304,9 @@ spec:
                 items:
                   description: LoadBalancerStatus 定义负载均衡器状态
                   properties:
+                    addressIPVersion:
+                      description: CLB 的 IP 版本，可选值：IPV4、IPV6、IPv6FullChain
+                      type: string
                     allocated:
                       description: 已分配的监听器数量
                       type: integer

--- a/incubator/tke-extend-network-controller/values.yaml
+++ b/incubator/tke-extend-network-controller/values.yaml
@@ -16,6 +16,14 @@ secretKey: ""
 # -- Cluster ID of the current TKE Cluster.
 clusterID: ""
 
+# -- Cloud API options
+cloudAPI:
+  # -- Cloud API endpoint suffix. Empty for production (clb.tencentcloudapi.com);
+  # set to "test" for test env, the SDK will call clb.test.tencentcloudapi.com etc.
+  endpointSuffix: ""
+  # -- IP of hostAliases to resolve cloud API domains
+  hostAliasesIP: "169.254.0.95"
+
 # -- Concurrency options of the controller, in large-scale rapid expansion scenarios,
 # the concurrency of the first 3 controllers can be appropriately increased
 # (mainly by batch creating clb listeners and binding rs to speed up the process).


### PR DESCRIPTION
## 更新内容

- 修复：chart 内置 CRD 与代码不一致（controller-tools v0.21.0 重新生成的 CRD 同步进 chart，补齐 `addressIPVersion` 等字段，避免 status 字段被 API Server 静默剪枝）
- 新增：支持测试环境云 API 域名（`cloudAPI.endpointSuffix`，默认留空行为与现网一致）

上游 Release：https://github.com/tkestack/tke-extend-network-controller/releases/tag/v2.5.2