### PR TITLE
tke-extend-network-controller: 同步 v2.6.0 chart 变更（云 API 默认内网域名与 environment 配置）并 bump to 2.6.0

### DIFF
--- a/incubator/tke-extend-network-controller/Chart.yaml
+++ b/incubator/tke-extend-network-controller/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.2
+version: 2.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2.5.2
+appVersion: 2.6.0
 kubeVersion: '>= 1.26.0-0'

--- a/incubator/tke-extend-network-controller/README.md
+++ b/incubator/tke-extend-network-controller/README.md
@@ -82,7 +82,8 @@ Kubernetes: `>= 1.26.0-0`
 | affinity | object | `{}` |  |
 | apiRateLimit | object | `{"BatchDeregisterTargets":20,"BatchRegisterTargets":20,"CreateListener":20,"DeleteLoadBalancerListeners":20,"DescribeListeners":20,"DescribeLoadBalancers":20,"DescribeTargets":20,"DescribeTaskStatus":20}` | Precisely control the QPS of cloud API calls to avoid frequent over-limits in large-scale scenarios, resulting in excessive retries and reduced scaling speed. |
 | clusterID | string | `""` | Cluster ID of the current TKE Cluster. |
-| concurrency | object | `{"clbNodeBindingController":20,"clbPodBindingController":20,"clbPortPoolController":10,"dedicatedClbListenerController":20,"dedicatedClbServiceController":1,"nodeController":20,"podController":20}` | Concurrency options of the controller, in large-scale rapid expansion scenarios, the concurrency of the first 3 controllers can be appropriately increased (mainly by batch creating clb listeners and binding rs to speed up the process). |
+| concurrency | object | `{"clbNodeBindingController":20,"clbPodBindingController":20,"clbPortPoolController":10,"nodeController":20,"podController":20}` | Concurrency options of the controller, in large-scale rapid expansion scenarios, the concurrency of the first 3 controllers can be appropriately increased (mainly by batch creating clb listeners and binding rs to speed up the process). |
+| environment | string | `"prod"` | Cloud API environment. Supported values are prod and test. prod uses clb.internal.tencentcloudapi.com; test uses clb.internal.test.tencentcloudapi.com. |
 | fullnameOverride | string | `""` |  |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"imroc/tke-extend-network-controller","tag":""}` | Image of the controller |
 | image.pullPolicy | string | `"IfNotPresent"` | ImagePullPolicy of the controller |

--- a/incubator/tke-extend-network-controller/templates/deployment.yaml
+++ b/incubator/tke-extend-network-controller/templates/deployment.yaml
@@ -1,5 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
+{{- $environment := "prod" }}
+{{- if hasKey .Values "environment" }}
+  {{- $environment = .Values.environment }}
+{{- else }}
+  {{- $environment = "prod" }}
+{{- end }}
+{{- if not (has $environment (list "prod" "test")) }}
+{{- fail "environment must be prod or test" }}
+{{- end }}
 metadata:
   labels:
     {{- include "tke-extend-network-controller.labels" . | nindent 4 }}
@@ -17,12 +26,6 @@ spec:
       labels:
         {{- include "tke-extend-network-controller.labels" . | nindent 8 }}
     spec:
-      hostAliases:
-      - hostnames:
-        {{- range $svc := list "clb" "vpc" "cam" "tag" }}
-        - {{ $svc }}{{ if $.Values.cloudAPI.endpointSuffix }}.{{ $.Values.cloudAPI.endpointSuffix }}{{ end }}.tencentcloudapi.com
-        {{- end }}
-        ip: {{ .Values.cloudAPI.hostAliasesIP }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -56,8 +59,8 @@ spec:
           value: "{{ .Values.concurrency.clbNodeBindingController }}"
         - name: WORKER_CLB_PORT_POOL_CONTROLLER
           value: "{{ .Values.concurrency.clbPortPoolController }}"
-        - name: CLOUD_API_ENDPOINT_SUFFIX
-          value: "{{ .Values.cloudAPI.endpointSuffix }}"
+        - name: CLOUD_API_ENVIRONMENT
+          value: "{{ $environment }}"
         - name: WORKER_POD_CONTROLLER
           value: "{{ .Values.concurrency.podController }}"
         - name: WORKER_NODE_CONTROLLER

--- a/incubator/tke-extend-network-controller/values.yaml
+++ b/incubator/tke-extend-network-controller/values.yaml
@@ -16,13 +16,9 @@ secretKey: ""
 # -- Cluster ID of the current TKE Cluster.
 clusterID: ""
 
-# -- Cloud API options
-cloudAPI:
-  # -- Cloud API endpoint suffix. Empty for production (clb.tencentcloudapi.com);
-  # set to "test" for test env, the SDK will call clb.test.tencentcloudapi.com etc.
-  endpointSuffix: ""
-  # -- IP of hostAliases to resolve cloud API domains
-  hostAliasesIP: "169.254.0.95"
+# -- Cloud API environment. Supported values are prod and test.
+# prod uses clb.internal.tencentcloudapi.com; test uses clb.internal.test.tencentcloudapi.com.
+environment: prod
 
 # -- Concurrency options of the controller, in large-scale rapid expansion scenarios,
 # the concurrency of the first 3 controllers can be appropriately increased


### PR DESCRIPTION
## 变更内容

同步 tke-extend-network-controller v2.6.0 chart 变更（对应上游 [v2.6.0 Release](https://github.com/tkestack/tke-extend-network-controller/releases/tag/v2.6.0)）：

- 新增顶层 `environment` 配置（仅支持 `prod` / `test`，默认 `prod`），移除 `cloudAPI.endpointSuffix` 与 `cloudAPI.hostAliasesIP` 配置
- deployment 移除固定解析云 API 域名的 hostAlias，改为注入 `CLOUD_API_ENVIRONMENT` 环境变量，并校验取值合法性
- 云 API 默认改走内网域名 `<service>.internal.tencentcloudapi.com`，域名解析交给集群 DNS
- version/appVersion bump 到 2.6.0
- README 补充 `environment` 参数说明，并修正 concurrency 默认值渲染（移除 values 中已不存在的 dedicatedClb* 控制器）

已通过 helm template 渲染验证：默认 prod、`environment=test` 注入正确，非法取值报错，hostAlias 不再渲染。